### PR TITLE
PR for beta-13 release. Vektis fix - but open slice

### DIFF
--- a/examples/KA-150-RelatedPerson-related-person.json
+++ b/examples/KA-150-RelatedPerson-related-person.json
@@ -8,7 +8,7 @@
   },
   "text": {
     "status": "extensions",
-    "div": "<div xmlns='http://www.w3.org/1999/xhtml'>skipping narratives</div>"
+    "div": "<div xmlns='http://www.w3.org/1999/xhtml'>skipping narratives!</div>"
   },
   "identifier": [
     {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koppeltaalv2.00",
-  "version": "0.14.0-beta.12",
+  "version": "0.14.0-beta.13",
   "description": "Draft of used FHIR resource profiles in Koppeltaal 2.0.",
   "title": "This package contains the Koppeltaal 2.0 profiles",
   "author": "VZVZ",

--- a/resources/KT2RelatedPerson.xml
+++ b/resources/KT2RelatedPerson.xml
@@ -2,7 +2,7 @@
 <StructureDefinition xmlns="http://hl7.org/fhir">
   <id value="KT2RelatedPerson" />
   <url value="http://koppeltaal.nl/fhir/StructureDefinition/KT2RelatedPerson" />
-  <version value="0.12.0" />
+  <version value="0.11.0" />
   <name value="KT2_RelatedPerson" />
   <status value="draft" />
   <fhirVersion value="4.0.1" />
@@ -31,27 +31,13 @@
       <path value="RelatedPerson.relationship" />
       <slicing>
         <discriminator>
-          <type value="pattern" />
+          <type value="value" />
           <path value="coding.system" />
         </discriminator>
         <rules value="closed" />
       </slicing>
       <comment value="See [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md?version=current) for more information on the ValueSet" />
       <min value="1" />
-      <patternCodeableConcept>
-        <coding>
-          <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.23.1" />
-        </coding>
-        <coding>
-          <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.23.1" />
-        </coding>
-        <coding>
-          <system value="http://terminology.hl7.org/CodeSystem/v3-RoleCode" />
-        </coding>
-        <coding>
-          <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
-        </coding>
-      </patternCodeableConcept>
     </element>
     <element id="RelatedPerson.relationship:role">
       <path value="RelatedPerson.relationship" />

--- a/resources/KT2RelatedPerson.xml
+++ b/resources/KT2RelatedPerson.xml
@@ -32,38 +32,31 @@
       <slicing>
         <discriminator>
           <type value="pattern" />
-          <path value="coding" />
+          <path value="coding.system" />
         </discriminator>
         <rules value="closed" />
       </slicing>
       <comment value="See [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md?version=current) for more information on the ValueSet" />
       <min value="1" />
+      <patternCodeableConcept>
+        <coding>
+          <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.23.1" />
+        </coding>
+        <coding>
+          <system value="urn:oid:2.16.840.1.113883.2.4.3.11.60.40.4.23.1" />
+        </coding>
+        <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/v3-RoleCode" />
+        </coding>
+        <coding>
+          <system value="http://terminology.hl7.org/CodeSystem/v3-NullFlavor" />
+        </coding>
+      </patternCodeableConcept>
     </element>
     <element id="RelatedPerson.relationship:role">
       <path value="RelatedPerson.relationship" />
       <sliceName value="role" />
       <comment value="When using the `display` element of a code you __MUST__ use the content of the `display` element of the code from the __CodeSystem__. Otherwise, validation will result in errors. Note that the display of the code in the ValueSet can be different." />
-    </element>
-    <element id="RelatedPerson.relationship:role.coding">
-      <path value="RelatedPerson.relationship.coding" />
-      <binding>
-        <strength value="required" />
-        <description value="The nature of the relationship between a patient and the related person." />
-        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.3.1.2--20200901000000" />
-      </binding>
-    </element>
-    <element id="RelatedPerson.relationship:relationship">
-      <path value="RelatedPerson.relationship" />
-      <sliceName value="relationship" />
-      <comment value="When using the `display` element of a code you __MUST__ use the content of the `display` element of the code from the __CodeSystem__. Otherwise, validation will result in errors. Note that the display of the code in the ValueSet can be different." />
-    </element>
-    <element id="RelatedPerson.relationship:relationship.coding">
-      <path value="RelatedPerson.relationship.coding" />
-      <binding>
-        <strength value="required" />
-        <description value="The nature of the relationship between a patient and the related person." />
-        <valueSet value="http://decor.nictiz.nl/fhir/ValueSet/2.16.840.1.113883.2.4.3.11.60.40.2.3.1.1--20200901000000" />
-      </binding>
     </element>
     <element id="RelatedPerson.name">
       <path value="RelatedPerson.name" />

--- a/resources/KT2RelatedPerson.xml
+++ b/resources/KT2RelatedPerson.xml
@@ -29,20 +29,15 @@
     </element>
     <element id="RelatedPerson.relationship">
       <path value="RelatedPerson.relationship" />
-      <slicing>
-        <discriminator>
-          <type value="value" />
-          <path value="coding.system" />
-        </discriminator>
-        <rules value="closed" />
-      </slicing>
-      <comment value="See [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md?version=current) for more information on the ValueSet" />
+      <comment
+        value="See [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md?version=current) for more information on the ValueSet" />
       <min value="1" />
     </element>
     <element id="RelatedPerson.relationship:role">
       <path value="RelatedPerson.relationship" />
       <sliceName value="role" />
-      <comment value="When using the `display` element of a code you __MUST__ use the content of the `display` element of the code from the __CodeSystem__. Otherwise, validation will result in errors. Note that the display of the code in the ValueSet can be different." />
+      <comment
+        value="When using the `display` element of a code you __MUST__ use the content of the `display` element of the code from the __CodeSystem__. Otherwise, validation will result in errors. Note that the display of the code in the ValueSet can be different." />
     </element>
     <element id="RelatedPerson.name">
       <path value="RelatedPerson.name" />
@@ -51,7 +46,8 @@
     <element id="RelatedPerson.name:nameInformation">
       <path value="RelatedPerson.name" />
       <sliceName value="nameInformation" />
-      <comment value="This `.name` element represents a Dutch name according to the [zib NameInformation (v1.1, 2020)](https://zibs.nl/wiki/NameInformation-v1.1(2020EN)) (except for the GivenName concept). A Dutch name is represented in FHIR as an ordinary international name, but is augmented using extensions to specify how the last name is built up according to the Dutch rules. See the guidance on `.family` and on `.extension:nameUsage` for more information. Systems that need to work in a Dutch context **MUST** support these extensions as specified here. In addition, systems **MUST** use the core elements according to the FHIR specifications to provide compatibility outside Dutch contexts. It is encouraged to provide a representation of the full name in the `.text` element.&#xD;&#xA;&#xD;&#xA;**Note 1**: The zib cannot be represented straightforward in FHIR. Especially note the guidance on `.given` on how to map the FirstNames and Initials concepts, and on `.prefix`/`.suffix` on how to map the Titles concept.&#xD;&#xA;&#xD;&#xA;**Note 2**: This element should only contain a person's _official_ names. The GivenName concept is represented in another `.name` element with `.name.use` = _usual_.&#xD;&#xA;&#xD;&#xA;**Note 3**: The examples illustrate how the zib is mapped to FHIR." />
+      <comment
+        value="This `.name` element represents a Dutch name according to the [zib NameInformation (v1.1, 2020)](https://zibs.nl/wiki/NameInformation-v1.1(2020EN)) (except for the GivenName concept). A Dutch name is represented in FHIR as an ordinary international name, but is augmented using extensions to specify how the last name is built up according to the Dutch rules. See the guidance on `.family` and on `.extension:nameUsage` for more information. Systems that need to work in a Dutch context **MUST** support these extensions as specified here. In addition, systems **MUST** use the core elements according to the FHIR specifications to provide compatibility outside Dutch contexts. It is encouraged to provide a representation of the full name in the `.text` element.&#xD;&#xA;&#xD;&#xA;**Note 1**: The zib cannot be represented straightforward in FHIR. Especially note the guidance on `.given` on how to map the FirstNames and Initials concepts, and on `.prefix`/`.suffix` on how to map the Titles concept.&#xD;&#xA;&#xD;&#xA;**Note 2**: This element should only contain a person's _official_ names. The GivenName concept is represented in another `.name` element with `.name.use` = _usual_.&#xD;&#xA;&#xD;&#xA;**Note 3**: The examples illustrate how the zib is mapped to FHIR." />
     </element>
     <element id="RelatedPerson.gender">
       <path value="RelatedPerson.gender" />


### PR DESCRIPTION
**What does this PR do?**
It creates a version of the beta-11 package, but without the closed slice. So the results should be a package that DOES contain a working Vektis `CodeSystem`, but not yet force the possible `CodeSystems` inside the relationship `ValueSets`.

I've reverted specific commits that were related to trying and close the slices. It does keep the general improvements like fixing examples.