### PR TITLE
KPTSTD-299: Bijwerken Koppetaal Implementation Guide met uitleg over RelatedPerson en de eigen Task + permissies 

### DIFF
--- a/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
+++ b/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
@@ -4,38 +4,43 @@ topic: RelatedPerson
 
 # {{page-title}}
 
-De Resource `RelatedPerson` is een nieuwe actor in de Koppeltaal Standaard. Bij een Related Person kunnen allerlei personen zijn, denk aan de volgende Rollen en Relaties.
+The `RelatedPerson` resource is a new actor in the Koppeltaal Standard. A `RelatedPerson` can represent various individuals, such as the following roles and relationships:
 
-* Ouder of Voogd,
-* Gemachtigde
-* Zorg Ondersteuner
-* etc.
+* Parent or Guardian
+* Authorized Representative
+* Care Supporter
 
-In het Element `RelatedPerson.relationship` wordt deze relatie vastgelegd. 
-In het Element `RelatedPerson.patient` bevat de referentie naar de `Patient`. Waarvoor betreffende actor een `RelatedPerson` is.
+The `RelatedPerson.relationship` element specifies this relationship. The `RelatedPerson.patient` element contains the reference to the `Patient` for whom the actor is a `RelatedPerson`.
 
-De `RelatedPerson` kan namens de `Patient` Taken uitvoeren, kan meekijken en ondersteunen bij taken van de `Patient`. Daarnaast heeft de `Patient` en `Practitioner` de mogelijkheid om de `RelatedPerson` toegang te ontzeggen aan een taak die was toegekend aan de `RelatedPerson`. 
+A `RelatedPerson` can perform tasks on behalf of the `Patient`, assist with the `Patient's` tasks, or view them. In addition, the `Patient` and `Practitioner` have the ability to revoke a `RelatedPerson's` access to a task that was assigned to the `RelatedPerson`.
 
-Hieronder wordt beschreven welke elementen een rol spelen bij het uitvoeren, meekijken en ontzeggen van toegang:
+Below is a description of the elements involved in executing tasks, viewing, and revoking access.
 
-## Taak uitvoeren door de RelatedPerson
+### Executing a Task by the RelatedPerson
 
-Wanneer een `RelatedPerson` een taak uitvoert en start via een launch 
- 1. De owner van de `Task` kan een `RelatedPerson` zijn: `Task.owner` = `Reference (KT2_RelatedPerson)` & `Task.for` = `Reference (KT2_Patient)`
- 2. De owner van `Task` kan ook een `CareTeam` waar `CareTeam.subject`= `Reference (KT2_Patient)` & `CareTeam.participant.member` = `Reference(KT2_RelatedPerson)` & `RelatedPerson.patient` = `Reference (KT2_Patient)` & `CareTeam.subject`=`RelatedPerson.patient`. 
+When a `RelatedPerson` executes a task and starts it via a launch:
+1. The owner of the `Task` can be a `RelatedPerson`:
+`Task.owner` = `Reference (KT2_RelatedPerson)`
+`Task.for` = `Reference (KT2_Patient)`
+2. The owner of the `Task` can also be a `CareTeam` where:
+    - `CareTeam.subject` = `Reference (KT2_Patient)`
+    - `CareTeam.participant.member` = `Reference (KT2_RelatedPerson)`
+    - `RelatedPerson.patient` = `Reference (KT2_Patient)`
+    - `CareTeam.subject` = `RelatedPerson.patient`.
 
-Deze condities moeten gecontroleerd worden door de lancerende applicatie.
+These conditions must be verified by the launching application.
 
-## Meekijken en ondersteunen bij een taak van de Patient
-Om het een `RelatedPerson` te laten meekijken met een taak van de patient zijn de volgende voorwaarden noodzakelijk.
+### Viewing and Supporting a Task of the Patient
+The following conditions are necessary for a `RelatedPerson` to view a task of the `Patient`:
+1. The task that the `RelatedPerson` performs should be a sub-task of the main task being performed by the patient:
+    - `Task.partOf` = `Reference (K2_Task)`
+    - `Task.owner` = `Reference (KT2_RelatedPerson)`
+    - `Task.code` = `view`.
 
- 1. De Taak die `RelatedPerson` uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: `Task.partOf` = `Reference (KT2_Task)` & `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.code`=`view`
+### Revoking Authorization for a Task to be Performed by a RelatedPerson
 
-Het ontzeggen van bevoegdheid om een taak door een `RelatedPerson` te laten uitvoeren
-
-Om duidelijk te maken dat een `RelatedPerson` niet meer bevoegd is tot het uitvoeren of inzien van een taak zijn er de volgende opties:
- 1. `Task.status` = `cancelled` 
- 2. `RelatedPerson.active` = `0` (inactive) 
- 3. `RelatedPerson.patient` <> `Task.owner`
- 4. `CareTeam.participant.kt2contactperson` is verwijderd uit het `CareTeam`
-
+To make it clear that a `RelatedPerson` is no longer authorized to perform or view a task, the following options are available:
+1. `Task.status` = `cancelled`
+2. `RelatedPerson.active` = `0` (inactive)
+3. `RelatedPerson.patient` <> `Task.owner`
+4. `CareTeam.participant.kt2contactperson` is removed from the `CareTeam`.

--- a/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
+++ b/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
@@ -1,0 +1,42 @@
+---
+topic: RelatedPerson
+---
+
+# {{page-title}}
+
+De Resource `RelatedPerson` is een nieuwe actor in de Koppeltaal Standaard. Bij een Related Person kunnen allerlei
+personen zijn, denk aan de volgende Rollen en Relaties.
+
+* Ouder of Voogd,
+* Gemachtigde
+* Zorg Ondersteuner
+* etc.
+
+In het Element RelatedPerson.relationship wordt deze relatie vastgelegd. 
+In het Element RelatedPerson.patient bevat de referentie naar de Patient. Waarvoor betreffende actor een RelatedPerson is.
+
+De RelatedPerson kan namens de Patient Taken uitvoeren, kan meekijken en ondersteunen bij taken van de Patient. Daarnaast heeft de Patient en Practitioner de mogelijkheid om de RelatedPerson toegang te ontzeggen aan een taak die was toegekend aan de RelatedPerson. 
+
+Hieronder wordt beschreven welke elementen een rol spelen bij het uitvoeren, meekijken en ontzeggen van toegang:
+
+## Taak uitvoeren door de RelatedPerson
+
+Wanneer een RelatedPerson een taak uitvoert en start via een launch 
+ 1. De owner van de Task kan een RelatedPerson zijn: Task.owner = Reference (KT2_RelatedPerson) & Task.for=Reference(KT2_Patient)
+ 2. De owner van Task kan ook een CareTeam waar CareTeam.subject=Reference (KT2_Patient) & CareTeam.participant.kt2contactperson=Reference(KT2_RelatedPerson) & RelatedPerson.patient=Reference (KT2_Patient) & CareTeam.subject=RelatedPerson.patient. 
+
+Deze condities moeten gecontroleerd worden door de lancerende applicatie.
+
+## Meekijken en ondersteunen bij een taak van de Patient. 
+Om het een RelatedPerson te laten meekijken met een taak van de patient zijn de volgende voorwaarden noodzakelijk.
+
+ 1. De Taak die RelatedPerson uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: Task.partOf = Reference (KT2_Task) & Task.owner = Reference (KT2_RelatedPerson) & Task.code="view"
+
+Het ontzeggen van bevoegdheid om een Taak door een RelatedPerson te laten uitvoeren
+
+Om duidelijk te maken dat een RelatedPerson niet meer bevoegd is tot het uitvoeren of inzien van een taak zijn er de volgende opties:
+ 1. Task.Status= “cancelled” 
+ 2. RelatedPerson.active = “0” (inactive) 
+ 3. RelatedPerson.patient<> Task.owner
+ 4. CareTeam.participant.kt2contactperson is verwijderd uit het CareTeam
+

--- a/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
+++ b/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
@@ -4,39 +4,38 @@ topic: RelatedPerson
 
 # {{page-title}}
 
-De Resource `RelatedPerson` is een nieuwe actor in de Koppeltaal Standaard. Bij een Related Person kunnen allerlei
-personen zijn, denk aan de volgende Rollen en Relaties.
+De Resource `RelatedPerson` is een nieuwe actor in de Koppeltaal Standaard. Bij een Related Person kunnen allerlei personen zijn, denk aan de volgende Rollen en Relaties.
 
 * Ouder of Voogd,
 * Gemachtigde
 * Zorg Ondersteuner
 * etc.
 
-In het Element RelatedPerson.relationship wordt deze relatie vastgelegd. 
-In het Element RelatedPerson.patient bevat de referentie naar de Patient. Waarvoor betreffende actor een RelatedPerson is.
+In het Element `RelatedPerson.relationship` wordt deze relatie vastgelegd. 
+In het Element `RelatedPerson.patient` bevat de referentie naar de `Patient`. Waarvoor betreffende actor een `RelatedPerson` is.
 
-De RelatedPerson kan namens de Patient Taken uitvoeren, kan meekijken en ondersteunen bij taken van de Patient. Daarnaast heeft de Patient en Practitioner de mogelijkheid om de RelatedPerson toegang te ontzeggen aan een taak die was toegekend aan de RelatedPerson. 
+De `RelatedPerson` kan namens de `Patient` Taken uitvoeren, kan meekijken en ondersteunen bij taken van de `Patient`. Daarnaast heeft de `Patient` en `Practitioner` de mogelijkheid om de `RelatedPerson` toegang te ontzeggen aan een taak die was toegekend aan de `RelatedPerson`. 
 
 Hieronder wordt beschreven welke elementen een rol spelen bij het uitvoeren, meekijken en ontzeggen van toegang:
 
 ## Taak uitvoeren door de RelatedPerson
 
-Wanneer een RelatedPerson een taak uitvoert en start via een launch 
- 1. De owner van de Task kan een RelatedPerson zijn: Task.owner = Reference (KT2_RelatedPerson) & Task.for=Reference(KT2_Patient)
- 2. De owner van Task kan ook een CareTeam waar CareTeam.subject=Reference (KT2_Patient) & CareTeam.participant.kt2contactperson=Reference(KT2_RelatedPerson) & RelatedPerson.patient=Reference (KT2_Patient) & CareTeam.subject=RelatedPerson.patient. 
+Wanneer een `RelatedPerson` een taak uitvoert en start via een launch 
+ 1. De owner van de `Task` kan een `RelatedPerson` zijn: `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.for` = `Reference` (KT2_Patient)
+ 2. De owner van `Task` kan ook een `CareTeam` waar `CareTeam.subject`= `Reference` (KT2_Patient) & `CareTeam.participant.kt2contactperson`=Reference(KT2_RelatedPerson) & `RelatedPerson.patient`=Reference (KT2_Patient) & `CareTeam.subject`=`RelatedPerson.patient`. 
 
 Deze condities moeten gecontroleerd worden door de lancerende applicatie.
 
-## Meekijken en ondersteunen bij een taak van de Patient. 
-Om het een RelatedPerson te laten meekijken met een taak van de patient zijn de volgende voorwaarden noodzakelijk.
+## Meekijken en ondersteunen bij een taak van de Patient
+Om het een `RelatedPerson` te laten meekijken met een taak van de patient zijn de volgende voorwaarden noodzakelijk.
 
- 1. De Taak die RelatedPerson uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: Task.partOf = Reference (KT2_Task) & Task.owner = Reference (KT2_RelatedPerson) & Task.code="view"
+ 1. De Taak die `RelatedPerson` uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: `Task.partOf` = `Reference` (KT2_Task) & `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.code`=`view`
 
-Het ontzeggen van bevoegdheid om een Taak door een RelatedPerson te laten uitvoeren
+Het ontzeggen van bevoegdheid om een taak door een `RelatedPerson` te laten uitvoeren
 
-Om duidelijk te maken dat een RelatedPerson niet meer bevoegd is tot het uitvoeren of inzien van een taak zijn er de volgende opties:
- 1. Task.Status= “cancelled” 
- 2. RelatedPerson.active = “0” (inactive) 
- 3. RelatedPerson.patient<> Task.owner
- 4. CareTeam.participant.kt2contactperson is verwijderd uit het CareTeam
+Om duidelijk te maken dat een `RelatedPerson` niet meer bevoegd is tot het uitvoeren of inzien van een taak zijn er de volgende opties:
+ 1. `Task.status` = `cancelled` 
+ 2. `RelatedPerson.active` = `0` (inactive) 
+ 3. `RelatedPerson.patient` <> `Task.owner`
+ 4. `CareTeam.participant.kt2contactperson` is verwijderd uit het `CareTeam`
 

--- a/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
+++ b/guides/koppeltaal/Home/General-Notes/RelatedPerson.md
@@ -21,15 +21,15 @@ Hieronder wordt beschreven welke elementen een rol spelen bij het uitvoeren, mee
 ## Taak uitvoeren door de RelatedPerson
 
 Wanneer een `RelatedPerson` een taak uitvoert en start via een launch 
- 1. De owner van de `Task` kan een `RelatedPerson` zijn: `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.for` = `Reference` (KT2_Patient)
- 2. De owner van `Task` kan ook een `CareTeam` waar `CareTeam.subject`= `Reference` (KT2_Patient) & `CareTeam.participant.kt2contactperson`=Reference(KT2_RelatedPerson) & `RelatedPerson.patient`=Reference (KT2_Patient) & `CareTeam.subject`=`RelatedPerson.patient`. 
+ 1. De owner van de `Task` kan een `RelatedPerson` zijn: `Task.owner` = `Reference (KT2_RelatedPerson)` & `Task.for` = `Reference (KT2_Patient)`
+ 2. De owner van `Task` kan ook een `CareTeam` waar `CareTeam.subject`= `Reference (KT2_Patient)` & `CareTeam.participant.member` = `Reference(KT2_RelatedPerson)` & `RelatedPerson.patient` = `Reference (KT2_Patient)` & `CareTeam.subject`=`RelatedPerson.patient`. 
 
 Deze condities moeten gecontroleerd worden door de lancerende applicatie.
 
 ## Meekijken en ondersteunen bij een taak van de Patient
 Om het een `RelatedPerson` te laten meekijken met een taak van de patient zijn de volgende voorwaarden noodzakelijk.
 
- 1. De Taak die `RelatedPerson` uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: `Task.partOf` = `Reference` (KT2_Task) & `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.code`=`view`
+ 1. De Taak die `RelatedPerson` uitvoert, moet een subtaak zijn van de hoofdtaak die door de Patient wordt uitgevoerd: `Task.partOf` = `Reference (KT2_Task)` & `Task.owner` = `Reference` (KT2_RelatedPerson) & `Task.code`=`view`
 
 Het ontzeggen van bevoegdheid om een taak door een `RelatedPerson` te laten uitvoeren
 

--- a/guides/koppeltaal/Home/General-Notes/Restrictions-on-elements.md
+++ b/guides/koppeltaal/Home/General-Notes/Restrictions-on-elements.md
@@ -7,7 +7,7 @@ Koppeltaal 2.0 adheres to the principle that elements of FHIR resources that are
 
 Especially the profiles that based on the national nl-core profiles will contain elements that are not defined in the Koppeltaal 2.0 specifications. 
 
-There are three ways this restrictuion on usage is expressed in the various profiles:
+There are three ways this restriction on usage is expressed in the various profiles:
 
 - cardinality set to 0
 - marking with 'not to be used'
@@ -39,7 +39,7 @@ The Identifier data type restricts the use to the elements `use`, `system` and `
 
 ### CodeableConcept and Coding
 
-The `userSelected` element of the Coding data type is not to be used. The Coding data type is also part of the CodeableConcept data type.
+The `userSelected` element of the Coding data type is not to be used. The Coding data type is also part of the `CodeableConcept` data type.
 
 {{render:guides-koppeltaal-assets-coding-restrictions}} 
 

--- a/guides/koppeltaal/Home/General-Notes/toc.yaml
+++ b/guides/koppeltaal/Home/General-Notes/toc.yaml
@@ -4,6 +4,8 @@
   filename: Restrictions-on-elements.md
 - name: Country Codes
   filename: Country-Codes.md
+- name: Related Person
+  filename: RelatedPerson.md
 - name: Examples
   filename: Examples.md
 - name: Strict use of Name Information

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/AuditEvent.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/AuditEvent.page.md
@@ -14,7 +14,7 @@ Note: for the code `transmit` use
 ```json
 {
     "system": "http://terminology.hl7.org/CodeSystem/iso-21089-lifecycle",
-    "code": "transmit
+    "code": "transmit"
 }
 ```
 
@@ -56,47 +56,53 @@ As mentioned above, there are several agent elements, one for the source, one fo
 
 _source_
 ```json
-"agent": [
+{
+  "agent": [
     {
-        "type": {
-            "coding": {
-                "system": "http://dicom.nema.org/resources/ontology/DCM",
-                "code": "110153"
-            }
-        },
-        "requestor": "true"
+      "type": {
+        "coding": {
+          "system": "http://dicom.nema.org/resources/ontology/DCM",
+          "code": "110153"
+        }
+      },
+      "requestor": "true"
     }
-]
+  ]
+}
 ```
 
 _destination_
 ```json
-"agent": [
+{
+  "agent": [
     {
-        "type": {
-            "coding": {
-                "system": "http://dicom.nema.org/resources/ontology/DCM",
-                "code": "110152"
-            }
-        },
-        "requestor": "false"
+      "type": {
+        "coding": {
+          "system": "http://dicom.nema.org/resources/ontology/DCM",
+          "code": "110152"
+        }
+      },
+      "requestor": "false"
     }
-]
+  ]
+}
 ```
 
 _patient_
 ```json
-"agent": [
+{
+  "agent": [
     {
-        "type": {
-            "coding": {
-                "system": "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
-                "code": "PAT"
-            }
-        },
-        "requestor": "false"
+      "type": {
+        "coding": {
+          "system": "http://terminology.hl7.org/CodeSystem/v3-RoleClass",
+          "code": "PAT"
+        }
+      },
+      "requestor": "false"
     }
-]
+  ]
+}
 ```
 
 ## Entity.type

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/CareTeam.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/CareTeam.page.md
@@ -15,6 +15,6 @@ Otherwise the subject element remains absent.
 
 For a healthcare professional the only applicable slice of `CareTeam.participant` is the slice `kt2healthcareProfessional`.
 
-This means the reference to the Practitionar should comply with the `KT2_Practitioner` profile.
+This means the reference to the Practitioner should comply with the `KT2_Practitioner` profile.
 
 The `practitioner.role` should comply to the codes defined in the ValueSet [ZorgverlenerRolCodelijst](https://simplifier.net/nictiz-r4-zib2020/2.16.840.1.113883.2.4.3.11.60.40.2.17.1.5--20200901000000).

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -6,9 +6,9 @@ topic: kt2relatedperson
 {{tree:http://koppeltaal.nl/fhir/StructureDefinition/KT2RelatedPerson}}
 
 ## KT2_RelatedPerson.relationship 
-De relatie(s) die Patient heeft met de RelatedPerson kan aan de hand van verschillende code systems worden vastgelegd, hieronder worden 3-tal voorbeelden worden getoond.
+De relatie(s) die `Patient` heeft met de `RelatedPerson` kan aan de hand van verschillende code systems worden vastgelegd, hieronder worden 3-tal voorbeelden worden getoond.
 
-De Patient kan meerdere relatie types onderhouden met RelatedPerson.
+De `Patient` kan meerdere relatie types onderhouden met `RelatedPerson`.
 
 Example: 
 
@@ -37,12 +37,12 @@ Example:
   }
 ```
 
-De KT2_RelatedPerson.Patient element bevat de referentie naar Patient waar betreffende patient aan gekoppeld is.  Zie hiervoor onderstaand voorbeeld: 
+De `KT2_RelatedPerson.patient` element bevat de referentie naar Patient waar betreffende patient aan gekoppeld is.  Zie hiervoor onderstaand voorbeeld: 
 
 ```JSON
 {
   "patient" : {
-    "reference" : "Patient/{PatientID}"
+    "reference" : "Patient/${PatientID}"
   }
   
 }

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -27,7 +27,7 @@ Example:
     {
       "coding": [
         {
-          "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472"
+          "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472",
           "code": "21",
           "display": "cliëntondersteuner"
         }

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -31,10 +31,10 @@ Example:
           "code": "21",
           "display": "cliëntondersteuner"
         }
-      }
       ]
     }
-  }
+  ]
+}
 ```
 
 De `KT2_RelatedPerson.patient` element bevat de referentie naar Patient waar betreffende patient aan gekoppeld is.  Zie hiervoor onderstaand voorbeeld: 

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -42,7 +42,7 @@ De KT2_RelatedPerson.Patient element bevat de referentie naar Patient waar betre
 ```JSON
 {
   "patient" : {
-    "reference" : "Patients/{PatientID}"
+    "reference" : "Patient/{PatientID}"
   }
   
 }

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -5,14 +5,15 @@ topic: kt2relatedperson
 
 {{tree:http://koppeltaal.nl/fhir/StructureDefinition/KT2RelatedPerson}}
 
-## KT2_RelatedPerson.relationship 
-De relatie(s) die `Patient` heeft met de `RelatedPerson` kan aan de hand van verschillende code systems worden vastgelegd, hieronder worden 3-tal voorbeelden worden getoond.
+## KT2_RelatedPerson.relationship
 
-De `Patient` kan meerdere relatie types onderhouden met `RelatedPerson`.
+The relationship(s) that the `Patient` has with the `RelatedPerson` can be documented using various code systems. Below, three examples are provided.
 
-Example: 
+A `Patient` can maintain multiple relationship types with a `RelatedPerson`.
 
-```json
+### Example:
+
+```JSON
 {
   "relationship": [
     {
@@ -37,13 +38,12 @@ Example:
 }
 ```
 
-De `KT2_RelatedPerson.patient` element bevat de referentie naar Patient waar betreffende patient aan gekoppeld is.  Zie hiervoor onderstaand voorbeeld: 
+The `KT2_RelatedPerson.patient` element contains the reference to the `Patient` to which the given `RelatedPerson` is linked. See the example below:
 
 ```JSON
 {
-  "patient" : {
-    "reference" : "Patient/${PatientID}"
+  "patient": {
+    "reference": "Patient/${PatientID}"
   }
-  
 }
 ```

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/RelatedPerson.page.md
@@ -5,3 +5,45 @@ topic: kt2relatedperson
 
 {{tree:http://koppeltaal.nl/fhir/StructureDefinition/KT2RelatedPerson}}
 
+## KT2_RelatedPerson.relationship 
+De relatie(s) die Patient heeft met de RelatedPerson kan aan de hand van verschillende code systems worden vastgelegd, hieronder worden 3-tal voorbeelden worden getoond.
+
+De Patient kan meerdere relatie types onderhouden met RelatedPerson.
+
+Example: 
+
+```json
+{
+  "relationship": [
+    {
+      "coding": [
+        {
+          "system": "http://terminology.h17.org/Codesystem/v3-RoleCode",
+          "code": "MTH",
+          "display": "Mother"
+        }
+      ]
+    },
+    {
+      "coding": [
+        {
+          "system": "urn:oid:2.16.840.1.113883.2.4.3.11.22.472"
+          "code": "21",
+          "display": "cliëntondersteuner"
+        }
+      }
+      ]
+    }
+  }
+```
+
+De KT2_RelatedPerson.Patient element bevat de referentie naar Patient waar betreffende patient aan gekoppeld is.  Zie hiervoor onderstaand voorbeeld: 
+
+```JSON
+{
+  "patient" : {
+    "reference" : "Patients/{PatientID}"
+  }
+  
+}
+```

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/Subscription.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/Subscription.page.md
@@ -11,4 +11,4 @@ topic: kt2subscription
 <span>⚠️ Warning</span>
 </div>
 
-It is the responsability of the developer to prevent endless loops, caused by sending a subscription to the original owner.
+It is the responsibility of the developer to prevent endless loops, caused by sending a subscription to the original owner.

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
@@ -18,7 +18,7 @@ Using the element `instantiatesCanonical` does not however allow chaining of the
 The element `instantiatesCanonical` should not be used for this reference. Receivers of a Task instance can ignore any value in the `instantiatesCanonical` and should look for the referred ActivityDefinition in the `instantiates` extension.
 
 ## KT2_Task.owner
-KT2_Task.owner bepaalt welke actor uitvoerder is van betreffende taak 
+`KT2_Task.owner` bepaalt welke actor uitvoerder is van betreffende taak.
 
 De RelatedPerson kan rechtstreeks als owner aan een taak worden toegekend.
 

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
@@ -16,3 +16,123 @@ A Task should refer to the ActivityDefinition it instantiates. This provides the
 Using the element `instantiatesCanonical` does not however allow chaining of the search parameters. Therefore this profile contains an extension `instantiates` which should hold the reference to the instantiated ActivityDefinition.
 
 The element `instantiatesCanonical` should not be used for this reference. Receivers of a Task instance can ignore any value in the `instantiatesCanonical` and should look for the referred ActivityDefinition in the `instantiates` extension.
+
+## KT2_Task.owner
+KT2_Task.owner bepaalt welke actor uitvoerder is van betreffende taak 
+
+De RelatedPerson kan rechtstreeks als owner aan een taak worden toegekend.
+
+```JSON
+{
+  "owner": {
+    "reference": "RelatedPerson/$(RelatedPersonId)",
+    "display": "KT2 Related Person"
+  }
+}
+```
+Of via een CareTeam 
+
+```JSON
+{
+  "owner": {
+    "reference": "CareTeam/$(CareTeamId}",
+    "display": "KT2 CareTeam"
+  }
+}
+```
+
+Voorbeeld:
+```JSON
+{
+    "resourceType" : "Task",
+    "meta" : {
+        "profile" : [
+            "http://koppeltaal.nl/fhir/StructureDefinition/KT2Task"
+        ]
+    },
+    "extension" : [
+        {
+            "url" : "http://vzvz.nl/fhir/StructureDefinition/instantiates",
+            "valueReference" : {
+                "reference" : "ActivityDefinition/8635519a-3ca5-4dc8-bd07-4ec1e7fefcd5",
+                "type" : "ActivityDefinition"
+            }
+        }
+    ],
+    "identifier" : [
+        {
+            "use" : "official",
+            "system" : "http:/vzvz.nl/Testtooling",
+            "value" : "Vragenlijst${IdentifierValue}"
+        }
+    ],
+    "description" : "Vul de vragenlijst zo goed mogelijk in. Dit kost ongeveer 10 minuten.",
+    "partOf" : [{
+        "reference" : "Task/1f2f427a-d7fd-4b91-809c-f4607365ce73",
+        "type" : "Task"
+    }],
+    "for" : {
+        "reference" : "Patient/810c315e-4720-4253-8369-1011f87691b6",
+        "type" : "Patient"
+    },
+    "intent" : "order",
+    "priority" : "routine",
+    "code" : {
+        "coding" : [
+            {
+                "system" : "http://vzvz.nl/fhir/CodeSystem/koppeltaal-task-code",
+                "code" : "view",
+                "display" : "This task can be viewed"
+            }
+        ]
+    },
+    "executionPeriod" : {
+        "start" : "2024-07-20T08:25:05+02:00"
+    },
+    "requester" : {
+        "reference" : "Practitioner/8849c230-5f03-4aab-83a0-8295dfc6000b",
+        "type" : "Practitioner"
+    },
+    "owner" : {
+        "reference" : "RelatedPerson/355651f0-2b28-4bf7-800d-0bbe4d96d793",
+        "type" : "RelatedPerson"
+    },
+    "status" : "ready",
+    "authoredOn" : "2024-07-30T08:25:05+02:00",
+    "lastModified" : "2024-07-30T09:45:05+02:00"
+}
+```
+
+## KT2_Task.partOf 
+Met behulp van dit element wordt, wanneer een KT2_RelatedPerson meekijkt met een taak van de KT2_Patient wordt de taak van RelatedPerson (KT2_Task.owner= RelatedPerson  die hiervoor gekoppeld als sub task aan een main task van een Patient waar KT2_Task.owner=Patient.  
+
+```JSON
+{
+  "for": {
+    "reference": "Patient/kt2-patient-example",
+    "display": "KT2 Patient"
+  },
+  "owner": {
+    "reference": "RelatedPerson/kt2-relatedperson-example",
+    "display": "KT2 Related Person"
+  },
+  "description": "Sub task for the KI2 Patient performed by a related person.",
+  "partof": [
+    {
+      "reference": "Task/kt2-maintask-example",
+      "display": "Main Task"
+    }
+  ]
+}
+```
+
+## KT2_Task.code
+
+Met behulp van dit element kan voor een KT2_Task de permissie op view worden gezet. Welke betekenis de view permissie bevat kan per Applicatie verschillen.
+
+```JSON
+{
+  "code": "view",
+  "display": "This task can be viewed"
+}
+```

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
@@ -135,7 +135,7 @@ In het voorbeeld hieronder staat een subtaak voor een `RelatedPerson` die gekopp
 
 ## KT2_Task.code
 
-Met behulp van dit element kan voor een `KT2_Task` de permissie op view worden gezet. Welke betekenis de view permissie bevat kan per applicatie verschillen.
+Met behulp van het `KT2_Task.code` element kan voor een `KT2_Task` de permissie op `view` worden gezet. Wat de exacte betekenis de `view` permissie is kan per applicatie verschillen, aangezien in koppeltaal 2.0 de autorisaties door de applicaties worden uitgevoerd.
 
 ```JSON
 {

--- a/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
+++ b/guides/koppeltaal/Home/Profile-Specific-Notes/Task.page.md
@@ -11,37 +11,39 @@ topic: kt2task
 <p><span>⚠️ Warning</span>&nbsp;As of 2023-11-02 the way the ActivityDefinition is referenced is changed!
 </div>
 
-A Task should refer to the ActivityDefinition it instantiates. This provides the possibility to search for Tasks that instantiate a specific instance of an ActivityDefinition, which in turn can be found based on its publisherId.
+A Task should refer to the `ActivityDefinition` it instantiates. This provides the possibility to search for Tasks that instantiate a specific instance of an `ActivityDefinition`, which in turn can be found based on its publisherId.
 
-Using the element `instantiatesCanonical` does not however allow chaining of the search parameters. Therefore this profile contains an extension `instantiates` which should hold the reference to the instantiated ActivityDefinition.
+Using the element `instantiatesCanonical` does not however allow chaining of the search parameters. Therefore this profile contains an extension `instantiates` which should hold the reference to the instantiated `ActivityDefinition`.
 
-The element `instantiatesCanonical` should not be used for this reference. Receivers of a Task instance can ignore any value in the `instantiatesCanonical` and should look for the referred ActivityDefinition in the `instantiates` extension.
+The element `instantiatesCanonical` should not be used for this reference. Receivers of a Task instance can ignore any value in the `instantiatesCanonical` and should look for the referred `ActivityDefinition` in the `instantiates` extension.
 
 ## KT2_Task.owner
 `KT2_Task.owner` bepaalt welke actor uitvoerder is van betreffende taak.
 
-De RelatedPerson kan rechtstreeks als owner aan een taak worden toegekend.
+De `RelatedPerson` kan rechtstreeks als owner aan een taak worden toegekend of via een `CareTeam`.
 
 ```JSON
 {
   "owner": {
-    "reference": "RelatedPerson/$(RelatedPersonId)",
+    "reference": "RelatedPerson/${RelatedPersonId}",
     "display": "KT2 Related Person"
   }
 }
 ```
-Of via een CareTeam 
+ 
 
 ```JSON
 {
   "owner": {
-    "reference": "CareTeam/$(CareTeamId}",
+    "reference": "CareTeam/${CareTeamId}",
     "display": "KT2 CareTeam"
   }
 }
 ```
 
-Voorbeeld:
+### Voorbeeld
+Beneden een voorbeeld met als owner een `RelatedPerson`.
+
 ```JSON
 {
     "resourceType" : "Task",
@@ -104,8 +106,13 @@ Voorbeeld:
 ```
 
 ## KT2_Task.partOf 
-Met behulp van dit element wordt, wanneer een KT2_RelatedPerson meekijkt met een taak van de KT2_Patient wordt de taak van RelatedPerson (KT2_Task.owner= RelatedPerson  die hiervoor gekoppeld als sub task aan een main task van een Patient waar KT2_Task.owner=Patient.  
+Met behulp van dit element wordt een subtaak aangemaakt. De hoofdtaak is is toegewezen aan de patient door `KT2_Task.owner`= `Reference (KT2_Patient)`. De subtaak wordt als volgt opgebouwd.
+* De `KT2_Task.partOf` wijst naar de hoofdtaak.
+* De `KT2_RelatedPerson` die meekijkt wordt de `Task.owner`
+* De `KT2_Task.for` wijst naar de `Patient` van de hoofdtaak.
 
+### Voorbeeld
+In het voorbeeld hieronder staat een subtaak voor een `RelatedPerson` die gekoppeld is aan een `Task` van de patient.
 ```JSON
 {
   "for": {
@@ -128,7 +135,7 @@ Met behulp van dit element wordt, wanneer een KT2_RelatedPerson meekijkt met een
 
 ## KT2_Task.code
 
-Met behulp van dit element kan voor een KT2_Task de permissie op view worden gezet. Welke betekenis de view permissie bevat kan per Applicatie verschillen.
+Met behulp van dit element kan voor een `KT2_Task` de permissie op view worden gezet. Welke betekenis de view permissie bevat kan per applicatie verschillen.
 
 ```JSON
 {


### PR DESCRIPTION
https://vzvz.atlassian.net/browse/KPTSTD-299

Add detailed documentation for the KT2 RelatedPerson and Task

Expanded the KT2 RelatedPerson and KT2 Task documentation, including relationship management, actor roles, and access permissions. Updated examples and structure to clarify how these elements interact within the Koppeltaal standard.

