### PR TITLE
feat(CareTeam): add custom CodeSystem for authorization roles

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -179,7 +179,7 @@ jobs:
             gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
               -X PATCH -F body=@/tmp/pr-comment.md
           else
-            gh pr comment "$PR_NUMBER" --body-file /tmp/pr-comment.md
+            gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" -F body=@/tmp/pr-comment.md
           fi
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -15,6 +15,7 @@ permissions:
   contents: write
   packages: write
   pages: write
+  pull-requests: write
 
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
@@ -113,6 +114,77 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v4
+
+  deploy-pr-preview:
+    name: Deploy PR Preview to Netlify
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref != 'refs/heads/main'
+    steps:
+      - name: Find associated PR
+        id: pr
+        run: |
+          PR_NUMBER=$(gh pr list --repo "$GITHUB_REPOSITORY" --head "$BRANCH_NAME" --state open --json number --jq '.[0].number')
+          if [ -z "$PR_NUMBER" ]; then
+            echo "No open PR found for branch $BRANCH_NAME"
+            echo "found=false" >> $GITHUB_OUTPUT
+          else
+            echo "Found PR #$PR_NUMBER"
+            echo "number=$PR_NUMBER" >> $GITHUB_OUTPUT
+            echo "found=true" >> $GITHUB_OUTPUT
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH_NAME: ${{ github.ref_name }}
+
+      - name: Download full build artifacts
+        if: steps.pr.outputs.found == 'true'
+        uses: actions/download-artifact@v4
+        with:
+          name: fhir-package-full
+
+      - name: Deploy to Netlify
+        if: steps.pr.outputs.found == 'true'
+        id: netlify
+        run: |
+          DEPLOY_URL=$(npx netlify-cli deploy \
+            --dir=./output \
+            --alias="pr-${PR_NUMBER}" \
+            --json | jq -r '.deploy_url')
+          echo "url=$DEPLOY_URL" >> $GITHUB_OUTPUT
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_PROJECT_ID }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+
+      - name: Post or update PR comment
+        if: steps.pr.outputs.found == 'true'
+        run: |
+          MARKER="<!-- ig-preview -->"
+
+          cat > /tmp/pr-comment.md <<EOF
+          ${MARKER}
+          ## IG Preview
+
+          The Implementation Guide for this PR is available at:
+          **${DEPLOY_URL}**
+
+          _Last updated: $(date -u '+%Y-%m-%d %H:%M UTC') | Commit: ${GITHUB_SHA::7}_
+          EOF
+
+          COMMENT_ID=$(gh api "repos/${GITHUB_REPOSITORY}/issues/${PR_NUMBER}/comments" --paginate \
+            --jq ".[] | select(.body | contains(\"${MARKER}\")) | .id" | head -1)
+
+          if [ -n "$COMMENT_ID" ]; then
+            gh api "repos/${GITHUB_REPOSITORY}/issues/comments/${COMMENT_ID}" \
+              -X PATCH -F body=@/tmp/pr-comment.md
+          else
+            gh pr comment "$PR_NUMBER" --body-file /tmp/pr-comment.md
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+          DEPLOY_URL: ${{ steps.netlify.outputs.url }}
 
   publish-npm-full:
     name: Publish Full Package to GitHub Packages

--- a/input/fsh/aliases.fsh
+++ b/input/fsh/aliases.fsh
@@ -37,4 +37,5 @@ Alias: $koppeltaal-endpoint-connection-type = http://vzvz.nl/fhir/CodeSystem/kop
 Alias: $koppeltaal-endpoint-connection-type-vs = http://vzvz.nl/fhir/ValueSet/endpoint-connection-type
 Alias: $koppeltaal-task-code = http://vzvz.nl/fhir/CodeSystem/koppeltaal-task-code
 Alias: $koppeltaal-task-code-vs = http://vzvz.nl/fhir/ValueSet/koppeltaal-task-code
+Alias: $koppeltaal-careteam-role = http://vzvz.nl/fhir/CodeSystem/koppeltaal-careteam-role
 Alias: $task-instantiates = http://vzvz.nl/fhir/StructureDefinition/instantiates

--- a/input/fsh/codesystems/KoppeltaalCareTeamRole.fsh
+++ b/input/fsh/codesystems/KoppeltaalCareTeamRole.fsh
@@ -1,0 +1,76 @@
+CodeSystem: KoppeltaalCareTeamRole
+Id: koppeltaal-careteam-role
+Title: "Koppeltaal CareTeam Participant Role"
+Description: """
+CodeSystem voor het vastleggen van rollen binnen een CareTeam in Koppeltaal 2.0.
+
+Deze rollen worden gebruikt voor autorisatiedoeleinden en bepalen welke permissies
+een deelnemer heeft binnen de context van een specifiek CareTeam. De permissies per
+rol zijn beschreven in de autorisatiematrices:
+- [Practitioner autorisaties](autorisaties-practitioner.html)
+- [RelatedPerson autorisaties](autorisaties-relatedperson.html)
+
+**Let op:** Deze codes representeren autorisatierollen, niet beroepen of klinische functies.
+Een verpleegkundige kan bijvoorbeeld de rol 'behandelaar' hebben in het ene CareTeam
+en 'zorgondersteuner' in een ander CareTeam.
+
+Wanneer een deelnemer geen code uit dit CodeSystem heeft, vallen de permissies terug
+op minimale rechten (zie de autorisatiematrices).
+"""
+* ^status = #active
+* ^content = #complete
+* ^date = 2026-02-12T12:00:00+01:00
+* insert ContactAndPublisher
+* ^url = "http://vzvz.nl/fhir/CodeSystem/koppeltaal-careteam-role"
+* ^version = "0.2.0"
+* ^experimental = false
+* ^caseSensitive = true
+* ^hierarchyMeaning = #grouped-by
+* ^property[+].code = #notSelectable
+* ^property[=].type = #boolean
+* ^property[=].description = "Indicates that the code is not intended to be chosen as a value by the user"
+
+// =============================================================================
+// Practitioner rollen
+// =============================================================================
+
+* #practitioner "Practitioner rollen" "Parent categorie voor alle Practitioner rollen binnen een CareTeam"
+  * ^property[0].code = #notSelectable
+  * ^property[=].valueBoolean = true
+
+* #practitioner #behandelaar "Behandelaar"
+    "Behandelend zorgverlener met volledige toegang tot patiënten in hun CareTeams.
+    Heeft CRUD rechten op taken van patiënten en kan taken starten."
+
+* #practitioner #zorgondersteuner "Zorgondersteuner"
+    "Ondersteunende rol (inclusief administratief medewerkers).
+    Kan taken klaarzetten voor patiënten maar kan deze niet zelf starten."
+
+* #practitioner #case-manager "Case Manager"
+    "Organisatie-breed overzicht en coördinatie.
+    Heeft leestoegang tot taken van alle patiënten binnen de organisatie en kan taken starten."
+
+// =============================================================================
+// RelatedPerson relaties
+// =============================================================================
+
+* #relatedperson "RelatedPerson relaties" "Parent categorie voor alle RelatedPerson relaties binnen een CareTeam"
+  * ^property[0].code = #notSelectable
+  * ^property[=].valueBoolean = true
+
+* #relatedperson #naaste "Naaste"
+    "Algemene naaste of verwant van de patiënt.
+    Kan meekijken, ondersteunen en communiceren. Heeft alleen toegang tot eigen taken."
+
+* #relatedperson #mantelzorger "Mantelzorger"
+    "Structurele informele zorgverlener.
+    Kan meekijken, beperkt uitvoeren, ondersteunen en communiceren.
+    Heeft leestoegang tot taken van de patiënt."
+
+* #relatedperson #wettelijk-vertegenwoordiger "Wettelijk vertegenwoordiger"
+    "Juridisch gemachtigd persoon om namens de patiënt te handelen.
+    Heeft volledige toegang tot taken van de patiënt en kan deze starten."
+
+* #relatedperson #buddy "Buddy"
+    "Ervaringsdeskundige begeleider.
+    Kan meekijken, ondersteunen en communiceren. Heeft alleen toegang tot eigen taken."

--- a/input/fsh/examples/careteam-deelnemers.fsh
+++ b/input/fsh/examples/careteam-deelnemers.fsh
@@ -17,14 +17,14 @@ Usage: #example
   * type = "Patient"
 * participant[0]
   * role
-    * coding = $v3-ParticipationType#RESP
-    * text = "Hoofdbehandelaar"
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
   * member = Reference(practitioner-volledig) "K. Jongen"
     * type = "Practitioner"
 * participant[+]
   * role
-    * coding = $sct#768832004
-    * text = "casemanager"
+    * coding = $koppeltaal-careteam-role#case-manager "Case Manager"
+    * text = "Case Manager"
   * member = Reference(practitioner-minimaal) "M. Splinter"
     * type = "Practitioner"
 * managingOrganization = Reference(organization-naam-type)

--- a/input/fsh/examples/careteam-koppeltaal-rollen.fsh
+++ b/input/fsh/examples/careteam-koppeltaal-rollen.fsh
@@ -1,0 +1,205 @@
+// =============================================================================
+// CareTeam voorbeelden met Koppeltaal-specifieke autorisatierollen
+// =============================================================================
+
+Instance: careteam-behandelaar
+InstanceOf: CareTeam
+Description: "Example of CareTeam with a Practitioner in the 'behandelaar' authorization role"
+Usage: #example
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2CareTeam"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>CareTeam met een behandelaar</div>"
+* insert NLlang
+* identifier
+  * use = #official
+  * system = "http://myTeam/id"
+  * value = "careteam-behandelaar-001"
+* status = #active
+* name = "Careteam met behandelaar"
+* subject = Reference(Patient/patient-met-resource-origin) "Patient, Berta Botje"
+  * type = "Patient"
+* participant[0]
+  * role
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
+  * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
+    * type = "Practitioner"
+* managingOrganization = Reference(Organization/organization-naam-type)
+  * type = "Organization"
+* extension
+  * url = "http://koppeltaal.nl/fhir/StructureDefinition/resource-origin"
+  * valueReference = Reference(Device/ba33314a-795a-4777-bef8-e6611f6be645)
+    * type = "Device"
+
+
+Instance: careteam-alle-practitioner-rollen
+InstanceOf: CareTeam
+Description: "Example of CareTeam demonstrating all Koppeltaal Practitioner authorization roles"
+Usage: #example
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2CareTeam"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>CareTeam met alle Practitioner autorisatierollen</div>"
+* insert NLlang
+* identifier
+  * use = #official
+  * system = "http://myTeam/id"
+  * value = "careteam-practitioner-rollen-001"
+* status = #active
+* name = "Careteam met alle practitioner rollen"
+* subject = Reference(Patient/patient-met-resource-origin) "Patient, Berta Botje"
+  * type = "Patient"
+* participant[0]
+  * role
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
+  * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
+    * type = "Practitioner"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#zorgondersteuner "Zorgondersteuner"
+    * text = "Zorgondersteuner"
+  * member = Reference(Practitioner/practitioner-minimaal) "M. Splinter"
+    * type = "Practitioner"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#case-manager "Case Manager"
+    * text = "Case Manager"
+  * member = Reference(Practitioner/practitioner-minimaal) "A. Coordinator"
+    * type = "Practitioner"
+* managingOrganization = Reference(Organization/organization-naam-type)
+  * type = "Organization"
+* extension
+  * url = "http://koppeltaal.nl/fhir/StructureDefinition/resource-origin"
+  * valueReference = Reference(Device/ba33314a-795a-4777-bef8-e6611f6be645)
+    * type = "Device"
+
+
+Instance: careteam-mantelzorger
+InstanceOf: CareTeam
+Description: "Example of CareTeam with a RelatedPerson in the 'mantelzorger' authorization role"
+Usage: #example
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2CareTeam"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>CareTeam met een mantelzorger</div>"
+* insert NLlang
+* identifier
+  * use = #official
+  * system = "http://myTeam/id"
+  * value = "careteam-mantelzorger-001"
+* status = #active
+* name = "Careteam met mantelzorger"
+* subject = Reference(Patient/patient-met-resource-origin) "Patient, Berta Botje"
+  * type = "Patient"
+* participant[0]
+  * role
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
+  * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
+    * type = "Practitioner"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#mantelzorger "Mantelzorger"
+    * text = "Mantelzorger"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "M. Buurvrouw"
+    * type = "RelatedPerson"
+* managingOrganization = Reference(Organization/organization-naam-type)
+  * type = "Organization"
+* extension
+  * url = "http://koppeltaal.nl/fhir/StructureDefinition/resource-origin"
+  * valueReference = Reference(Device/ba33314a-795a-4777-bef8-e6611f6be645)
+    * type = "Device"
+
+
+Instance: careteam-wettelijk-vertegenwoordiger
+InstanceOf: CareTeam
+Description: "Example of CareTeam with a RelatedPerson as 'wettelijk vertegenwoordiger' (legal representative)"
+Usage: #example
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2CareTeam"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>CareTeam met een wettelijk vertegenwoordiger</div>"
+* insert NLlang
+* identifier
+  * use = #official
+  * system = "http://myTeam/id"
+  * value = "careteam-wv-001"
+* status = #active
+* name = "Careteam met wettelijk vertegenwoordiger"
+* subject = Reference(Patient/patient-met-resource-origin) "Patient, Berta Botje"
+  * type = "Patient"
+* participant[0]
+  * role
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
+  * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
+    * type = "Practitioner"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#wettelijk-vertegenwoordiger "Wettelijk vertegenwoordiger"
+    * text = "Wettelijk vertegenwoordiger"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "J. Voogd"
+    * type = "RelatedPerson"
+* managingOrganization = Reference(Organization/organization-naam-type)
+  * type = "Organization"
+* extension
+  * url = "http://koppeltaal.nl/fhir/StructureDefinition/resource-origin"
+  * valueReference = Reference(Device/ba33314a-795a-4777-bef8-e6611f6be645)
+    * type = "Device"
+
+
+Instance: careteam-alle-relatedperson-rollen
+InstanceOf: CareTeam
+Description: "Example of CareTeam demonstrating all Koppeltaal RelatedPerson authorization roles"
+Usage: #example
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2CareTeam"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>CareTeam met alle RelatedPerson autorisatierollen</div>"
+* insert NLlang
+* identifier
+  * use = #official
+  * system = "http://myTeam/id"
+  * value = "careteam-relatedperson-rollen-001"
+* status = #active
+* name = "Careteam met alle relatedperson rollen"
+* subject = Reference(Patient/patient-met-resource-origin) "Patient, Berta Botje"
+  * type = "Patient"
+* participant[0]
+  * role
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
+  * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
+    * type = "Practitioner"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#naaste "Naaste"
+    * text = "Naaste"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "A. Familie"
+    * type = "RelatedPerson"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#mantelzorger "Mantelzorger"
+    * text = "Mantelzorger"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "B. Zorger"
+    * type = "RelatedPerson"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#wettelijk-vertegenwoordiger "Wettelijk vertegenwoordiger"
+    * text = "Wettelijk vertegenwoordiger"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "C. Voogd"
+    * type = "RelatedPerson"
+* participant[+]
+  * role
+    * coding = $koppeltaal-careteam-role#buddy "Buddy"
+    * text = "Buddy"
+  * member = Reference(RelatedPerson/relatedperson-minimal) "D. Maatje"
+    * type = "RelatedPerson"
+* managingOrganization = Reference(Organization/organization-naam-type)
+  * type = "Organization"
+* extension
+  * url = "http://koppeltaal.nl/fhir/StructureDefinition/resource-origin"
+  * valueReference = Reference(Device/ba33314a-795a-4777-bef8-e6611f6be645)
+    * type = "Device"

--- a/input/fsh/examples/careteam-related-person.fsh
+++ b/input/fsh/examples/careteam-related-person.fsh
@@ -17,20 +17,20 @@ Usage: #example
   * type = "Patient"
 * participant[0]
   * role
-    * coding = $v3-ParticipationType#RESP
-    * text = "Hoofdbehandelaar"
+    * coding = $koppeltaal-careteam-role#behandelaar "Behandelaar"
+    * text = "Behandelaar"
   * member = Reference(Practitioner/practitioner-volledig) "K. Jongen"
     * type = "Practitioner"
 * participant[+]
   * role
-    * coding = $sct#768832004
-    * text = "casemanager"
+    * coding = $koppeltaal-careteam-role#case-manager "Case Manager"
+    * text = "Case Manager"
   * member = Reference(Practitioner/practitioner-minimaal) "M. Splinter"
     * type = "Practitioner"
 * participant[+]
   * role
-    * coding = $sct#768832004
-    * text = "casemanager"
+    * coding = $koppeltaal-careteam-role#naaste "Naaste"
+    * text = "Naaste"
   * member = Reference(RelatedPerson/relatedperson-minimal) "M. Buurvrouw"
     * type = "RelatedPerson"
 * managingOrganization = Reference(Organization/organization-naam-type)

--- a/input/fsh/profiles/KT2_CareTeam.fsh
+++ b/input/fsh/profiles/KT2_CareTeam.fsh
@@ -25,19 +25,27 @@ Id: KT2CareTeam
 * participant contains
  kt2contactperson 0..* and
  kt2healthcareProfessional 0..*
+* participant[kt2contactperson].role ^slicing.discriminator.type = #value
+* participant[kt2contactperson].role ^slicing.discriminator.path = "$this"
+* participant[kt2contactperson].role ^slicing.rules = #open
+* participant[kt2contactperson].role ^comment = "The role defines the authorization level for this RelatedPerson within the CareTeam. See [RelatedPerson autorisaties](autorisaties-relatedperson.html) for the permission matrix."
+* participant[kt2contactperson].role contains kt2Role 0..1
+* participant[kt2contactperson].role[kt2Role] from KoppeltaalRelatedPersonRoleValueSet (extensible)
+* participant[kt2contactperson].role[kt2Role] ^definition = "The authorization role of the RelatedPerson within this CareTeam. Determines which actions this person may perform."
+* participant[kt2contactperson].role[kt2Role] ^binding.description = "Koppeltaal authorization roles for RelatedPersons in a CareTeam."
 * participant[kt2contactperson].member only Reference(KT2_RelatedPerson)
 * participant[kt2contactperson].onBehalfOf ^comment = "This element is not used in the context of Koppeltaal 2.0"
 * participant[kt2contactperson].period ^comment = "This element is not used in the context of Koppeltaal 2.0"
 * participant[kt2healthcareProfessional].role ^slicing.discriminator.type = #value
 * participant[kt2healthcareProfessional].role ^slicing.discriminator.path = "$this"
 * participant[kt2healthcareProfessional].role ^slicing.rules = #open
-* participant[kt2healthcareProfessional].role ^comment = "See [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/CareTeam.page.md?version=current) for more information on the ValueSet of the role."
+* participant[kt2healthcareProfessional].role ^comment = "The role defines the authorization level for this Practitioner within the CareTeam. See [Practitioner autorisaties](autorisaties-practitioner.html) for the permission matrix."
 * participant[kt2healthcareProfessional].role contains healthProfessionalRole 0..1
-* participant[kt2healthcareProfessional].role[healthProfessionalRole] from ZorgverlenerRolCodelijst (required)
-* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^definition = "The role the health professional fulfils in the healthcare process. For health professionals, this could be for example attender, referrer or performer."
-* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^comment = "Roles may sometimes be inferred by type of Practitioner.  These are relationships that hold only within the context of the care team.  General relationships should be handled as properties of the Patient resource directly.\r\n\r\nFor more information see: [Koppeltaal Implementation Guide](https://simplifier.net/guide/koppeltaal/Home/Profile-Specific-Notes/CareTeam.page.md?version=current)"
-* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^alias = "ZorgverlenerRolCodelijst"
-* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^binding.description = "The role the health professional fulfils in the healthcare process."
+* participant[kt2healthcareProfessional].role[healthProfessionalRole] from KoppeltaalPractitionerRoleValueSet (extensible)
+* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^definition = "The authorization role of the Practitioner within this CareTeam. Determines which actions this person may perform. This ValueSet extends the ZorgverlenerRolCodelijst with Koppeltaal-specific authorization roles."
+* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^comment = "For authorization purposes, use the Koppeltaal-specific codes (behandelaar, zorgondersteuner, case-manager). The ZorgverlenerRolCodelijst codes are included for backwards compatibility.\r\n\r\nSee [Rol Code Mapping](autorisaties-rol-code-mapping.html) for more information."
+* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^alias = "KoppeltaalPractitionerRole"
+* participant[kt2healthcareProfessional].role[healthProfessionalRole] ^binding.description = "Koppeltaal authorization roles for Practitioners in a CareTeam (extends ZorgverlenerRolCodelijst)."
 * participant[kt2healthcareProfessional].member only Reference(KT2_Practitioner)
 * participant[kt2healthcareProfessional].member ^comment = "This element is used in Koppeltaal 2.0 to refer to the Practitioner who is member of the team"
 * participant[kt2healthcareProfessional].onBehalfOf ^comment = "This element is not used in the context of Koppeltaal 2.0"

--- a/input/fsh/profiles/KT2_CareTeam.fsh
+++ b/input/fsh/profiles/KT2_CareTeam.fsh
@@ -17,9 +17,8 @@ Id: KT2CareTeam
 * encounter ..0
 * participant ^comment = "WARNING: `allSlices` is a display bug in Simplifier.net. There is no `allSlices` slice. Firely is already notified of this bug."
 * participant[contactPerson] ..0
-* participant[patient].member only Reference(KT2_Patient)
-* participant[patient].onBehalfOf ^comment = "This element is not used in the context of Koppeltaal 2.0"
-* participant[patient].period ^comment = "This element is not used in the context of Koppeltaal 2.0"
+* participant[patient] ..0
+* participant[patient] ^comment = "This slice is not used in the context of Koppeltaal 2.0. The patient is always represented via CareTeam.subject, not as a participant member."
 * participant[healthcareProfessional] ..0
 * participant[healthcareProfessional] ^comment = "This slice is not used in the context of Koppeltaal 2.0"
 * participant contains

--- a/input/fsh/valuesets/KoppeltaalCareTeamRole.fsh
+++ b/input/fsh/valuesets/KoppeltaalCareTeamRole.fsh
@@ -1,0 +1,46 @@
+ValueSet: KoppeltaalPractitionerRoleValueSet
+Id: koppeltaal-practitioner-role
+Title: "Koppeltaal Practitioner Role ValueSet"
+Description: """
+ValueSet voor Practitioner rollen binnen een CareTeam.
+
+Breidt de ZorgverlenerRolCodelijst uit met Koppeltaal-specifieke autorisatierollen
+voor Practitioners. Zie [Practitioner autorisaties](autorisaties-practitioner.html).
+"""
+* ^status = #active
+* ^experimental = false
+* ^date = 2026-02-12T12:00:00+01:00
+* insert ContactAndPublisher
+* ^url = "http://vzvz.nl/fhir/ValueSet/koppeltaal-practitioner-role"
+* ^version = "0.2.0"
+
+// Include bestaande ZorgverlenerRolCodelijst voor backwards compatibility
+* include codes from valueset ZorgverlenerRolCodelijst
+
+// Koppeltaal-specifieke Practitioner rollen
+* $koppeltaal-careteam-role#behandelaar "Behandelaar"
+* $koppeltaal-careteam-role#zorgondersteuner "Zorgondersteuner"
+* $koppeltaal-careteam-role#case-manager "Case Manager"
+
+
+ValueSet: KoppeltaalRelatedPersonRoleValueSet
+Id: koppeltaal-relatedperson-role
+Title: "Koppeltaal RelatedPerson Role ValueSet"
+Description: """
+ValueSet voor RelatedPerson relaties binnen een CareTeam.
+
+Bevat Koppeltaal-specifieke relatie codes die de autorisaties bepalen voor
+naasten van de patiënt. Zie [RelatedPerson autorisaties](autorisaties-relatedperson.html).
+"""
+* ^status = #active
+* ^experimental = false
+* ^date = 2026-02-12T12:00:00+01:00
+* insert ContactAndPublisher
+* ^url = "http://vzvz.nl/fhir/ValueSet/koppeltaal-relatedperson-role"
+* ^version = "0.2.0"
+
+// Koppeltaal-specifieke RelatedPerson relaties
+* $koppeltaal-careteam-role#naaste "Naaste"
+* $koppeltaal-careteam-role#mantelzorger "Mantelzorger"
+* $koppeltaal-careteam-role#wettelijk-vertegenwoordiger "Wettelijk vertegenwoordiger"
+* $koppeltaal-careteam-role#buddy "Buddy"

--- a/input/intro-notes/StructureDefinition-KT2CareTeam-notes.md
+++ b/input/intro-notes/StructureDefinition-KT2CareTeam-notes.md
@@ -7,13 +7,15 @@ Otherwise the subject element remains absent.
 
 #### Participant Role
 
-For a healthcare professional the only applicable slice of `CareTeam.participant` is the slice `kt2healthcareProfessional`
+For a healthcare professional the only applicable slice of `CareTeam.participant` is the slice `kt2healthcareProfessional`.
 This means the reference to the Practitioner should comply with the `KT2_Practitioner` profile.
+The role should comply to the codes defined in the [KoppeltaalPractitionerRoleValueSet](ValueSet-koppeltaal-practitioner-role.html), which extends the ZorgverlenerRolCodelijst with Koppeltaal-specific authorization roles.
 
-For a RelatedPerson the applicable slice  of CareTeam.participant' is the slice 'kt2contactperson'
-This means the reference to the RelatedPerson should comply with the 'KT2_RelatedPerson' profile.
+For a RelatedPerson the applicable slice of `CareTeam.participant` is the slice `kt2contactperson`.
+This means the reference to the RelatedPerson should comply with the `KT2_RelatedPerson` profile.
+The role should comply to the codes defined in the [KoppeltaalRelatedPersonRoleValueSet](ValueSet-koppeltaal-relatedperson-role.html).
 
-The `practitioner.role` should comply to the codes defined in the ValueSet [ZorgverlenerRolCodelijst](https://simplifier.net/nictiz-r4-zib2020/2.16.840.1.113883.2.4.3.11.60.40.2.17.1.5--20200901000000).
+See [Rol Code Mapping](autorisaties-rol-code-mapping.html) for detailed information on how roles map to authorization levels.
 
 #### Validation: CareTeam operations
 

--- a/input/pagecontent/autorisaties-relatedperson.md
+++ b/input/pagecontent/autorisaties-relatedperson.md
@@ -74,7 +74,7 @@ De Task en Task Launch rechten zijn direct gekoppeld aan de bevoegdheden per rel
 **Toelichting:**
 - **Eigen taak**: Taken waar de RelatedPerson eigenaar van is
 - **Patiënt taak**: Taken die voor de patiënt zijn aangemaakt (door behandelaar)
-- **Overige relaties**: Fallback voor FHIR/SNOMED relaties die niet in bovenstaande categorieën vallen
+- **Overige relaties**: Fallback voor relaties die niet in bovenstaande categorieën vallen
 
 ##### Geen relatie in CareTeam
 
@@ -149,7 +149,7 @@ De Buddy is een ervaringsdeskundige begeleider met vergelijkbare rechten als de 
 
 ##### Overige relaties
 
-Dit is de fallback categorie voor RelatedPersons met een relatie die niet in de bovenstaande categorieën valt. Dit kunnen andere FHIR of SNOMED relatie-codes zijn die niet expliciet zijn gedefinieerd. Deze RelatedPersons krijgen minimale rechten, vergelijkbaar met "Geen relatie in CareTeam".
+Dit is de fallback categorie voor RelatedPersons met een relatie die niet in de bovenstaande categorieën valt. Dit kunnen codes zijn die niet in het [Koppeltaal CareTeam Role CodeSystem](CodeSystem-koppeltaal-careteam-role.html) zijn gedefinieerd. Deze RelatedPersons krijgen minimale rechten, vergelijkbaar met "Geen relatie in CareTeam".
 
 | Entiteit               | Toegang                                    | CRUD   | Search Narrowing                                                |
 |------------------------|--------------------------------------------|--------|-----------------------------------------------------------------|

--- a/input/pagecontent/autorisaties-rol-code-mapping.md
+++ b/input/pagecontent/autorisaties-rol-code-mapping.md
@@ -1,172 +1,60 @@
 ### Changelog
 
-| Versie | Datum      | Wijziging                                      |
-|--------|------------|------------------------------------------------|
-| 0.0.3  | 2026-01-20 | RelatedPerson code mapping toegevoegd          |
-| 0.0.2  | 2026-01-20 | Codes bijgewerkt op basis van review           |
-| 0.0.1  | 2026-01-20 | Initiële versie met SNOMED CT code mapping     |
+| Versie | Datum      | Wijziging                                                              |
+|--------|------------|------------------------------------------------------------------------|
+| 0.2.0  | 2026-02-12 | SNOMED CT mapping vervangen door eigen Koppeltaal CodeSystem           |
+| 0.1.0  | 2026-01-22 | Koppeltaal CodeSystem geïntroduceerd voor autorisatierollen            |
+| 0.0.3  | 2026-01-20 | RelatedPerson code mapping toegevoegd                                  |
+| 0.0.2  | 2026-01-20 | Codes bijgewerkt op basis van review                                   |
+| 0.0.1  | 2026-01-20 | Initiële versie met SNOMED CT code mapping                             |
 
 ---
 
-### Rol Code Mapping voor Autorisaties
+### Autorisatierollen CodeSystem
 
-Deze pagina beschrijft de mapping tussen de functionele rollen zoals gedefinieerd in de autorisatieregels en de bijbehorende SNOMED CT codes. Deze codes kunnen worden gebruikt voor:
-- Het `PractitionerRole.code` element om de rol van een Practitioner te identificeren
-- Het `RelatedPerson.relationship` element om de relatie van een RelatedPerson te identificeren
+Koppeltaal 2.0 definieert een eigen CodeSystem voor autorisatierollen binnen CareTeams. Deze rollen bepalen welke permissies een deelnemer heeft binnen de context van een specifiek CareTeam.
 
-#### Practitioner Code Mapping
+#### Waarom een eigen CodeSystem?
 
-| Situatie                                  | SNOMED CT Code | SNOMED CT Term                               | Omschrijving                                      |
-|:------------------------------------------|:---------------|:---------------------------------------------|:--------------------------------------------------|
-| **Behandelaar in CareTeam**               | `405623001`    | Assigned practitioner (occupation)           | Toegewezen zorgverlener met volledige toegang     |
-| **Zorgondersteuner/Administratief mdw**   | `224609002`    | Administrative healthcare staff (occupation) | Ondersteunende rol, taken klaarzetten             |
-| **Case Manager**                          | `224608005`    | Case manager (occupation)                    | Organisatie-breed overzicht en coördinatie        |
-| **Practitioner zonder rol in CareTeam**   | `223366009`    | Healthcare professional (occupation)         | Geen specifieke CareTeam rol                      |
-| **Overige rollen**                        | -              | -                                            | Fallback voor onbekende UZI/BIG rollen            |
+De Nederlandse FHIR-standaarden (zibs) gebruiken voor CareTeam-rollen de [ZorgverlenerRolCodelijst](https://simplifier.net/nictiz-r4-zib2020/2.16.840.1.113883.2.4.3.11.60.40.2.17.1.5--20200901000000), die voornamelijk HL7v3 ParticipationType codes bevat (ATND, RESP, REF, etc.) en één SNOMED code (768832004 = Case manager). Deze codes beschrijven klinische participatietypen, geen autorisatieniveaus. Koppeltaal heeft behoefte aan codes die direct gekoppeld zijn aan permissies. Dit is een functionele uitbreiding op de bestaande zibs.
 
-#### Code System
+De keuze voor een eigen CodeSystem in plaats van SNOMED:
 
-De codes komen uit het SNOMED CT code system:
+1. **Expliciete autorisatie**: Codes uit het Koppeltaal CodeSystem kunnen alleen bewust zijn toegekend. Bij hergebruik van bestaande codes (SNOMED, HL7v3) bestaat het risico dat codes die in een andere context zijn toegevoegd onbedoeld permissies triggeren wanneer een resource Koppeltaal binnenkomt.
+2. **Geen meerwaarde van SNOMED**: Elke uitbreiding op de zib — of het nu SNOMED of custom is — is niet herkenbaar in andere standaarden. SNOMED voegt hier geen interoperabiliteit toe omdat het gaat om Koppeltaal-specifieke autorisatierollen die in andere contexten niet bestaan.
+3. **Eenvoudig**: Directe mapping tussen code en permissiematrix, geen terminologieserver nodig.
+4. **Stabiel**: Koppeltaal heeft volledige controle over de codes en hun betekenis. Geen risico op wijzigingen door externe partijen.
+5. **Backwards compatible**: De ValueSets breiden de bestaande ZorgverlenerRolCodelijst uit.
+
+#### CodeSystem
 
 ```
-CodeSystem: http://snomed.info/sct
+CodeSystem: http://vzvz.nl/fhir/CodeSystem/koppeltaal-careteam-role
 ```
-
-#### Detailbeschrijving per code
-
-##### 405623001 - Assigned practitioner (occupation)
-
-Deze code wordt gebruikt voor toegewezen zorgverleners (behandelaars) die actief betrokken zijn bij de behandeling van een patiënt. In het autorisatiemodel wordt deze code gebruikt voor:
-- Behandelaars in een CareTeam
-- Zorgverleners met volledige CRUD rechten op patiëntgegevens binnen hun CareTeams
-
-##### 224609002 - Administrative healthcare staff (occupation)
-
-Deze code is bedoeld voor medewerkers met een administratieve of ondersteunende rol binnen de zorgorganisatie. In het autorisatiemodel wordt deze code gebruikt voor:
-- Zorgondersteuners
-- Secretariaatsmedewerkers
-- Administratief medewerkers
-- Medewerkers die taken kunnen klaarzetten maar niet zelf kunnen starten
-
-##### 224608005 - Case manager (occupation)
-
-De Case manager code wordt gebruikt voor medewerkers met een coördinerende rol. In het autorisatiemodel is dit de Case Manager die:
-- Organisatie-breed overzicht heeft
-- Taken van alle patiënten binnen de organisatie kan inzien
-- Taken kan starten voor patiënten binnen de organisatie
-
-##### 223366009 - Healthcare professional (occupation)
-
-Dit is de algemene parent categorie voor alle zorgverleners in SNOMED CT. Deze code wordt gebruikt als fallback voor:
-- Practitioners zonder specifieke rol in een CareTeam
-- Situaties waarin geen specifiekere code beschikbaar is
-
-De SNOMED CT hiërarchie onder deze code bevat circa 500 subcategorieën voor meer specifieke rollen zoals artsen, verpleegkundigen en paramedici.
-
-#### Alternatieve Practitioner codes
-
-Afhankelijk van de specifieke context kunnen de volgende alternatieve codes worden overwogen:
-
-| SNOMED CT Code | SNOMED CT Term                    | Mogelijk gebruik                                |
-|:---------------|:----------------------------------|:------------------------------------------------|
-| `223366009`    | Healthcare professional           | Generieke zorgverlener (parent categorie)       |
-| `768820003`    | Care coordinator (occupation)     | Alternatief voor Case Manager                   |
-| `224577009`    | Healthcare assistant (occupation) | Zorgondersteuner met direct patiëntcontact      |
-| `394618009`    | Medical secretary (occupation)    | Specifiek voor medisch secretariaat             |
 
 ---
 
-#### RelatedPerson Code Mapping
+### Practitioner Rollen
 
-De onderstaande tabel toont de mapping voor RelatedPerson relaties zoals gedefinieerd in de [RelatedPerson autorisaties](autorisaties-relatedperson.html).
+De onderstaande rollen zijn beschikbaar voor Practitioners binnen een CareTeam. De permissies per rol zijn beschreven in [Practitioner autorisaties](autorisaties-practitioner.html).
 
-| Relatie                         | SNOMED CT Code | SNOMED CT Term                    | Omschrijving                                |
-|:--------------------------------|:---------------|:----------------------------------|:--------------------------------------------|
-| **Mantelzorger**                | `224610006`    | Carer (person)                    | Structurele informele zorgverlener          |
-| **Wettelijk vertegenwoordiger** | `419358007`    | Legal guardian (person)           | Juridisch gemachtigd persoon                |
-| **Naaste**                      | `133932002`    | Caregiver (person)                | Algemene naaste/verwant                     |
-| **Buddy**                       | `125680007`    | Friend (person)                   | Ervaringsdeskundige begeleider              |
-| **Geen rol in CareTeam**        | -              | -                                 | Niet opgenomen in CareTeam                  |
-| **Overige relaties**            | -              | -                                 | Fallback voor onbekende relaties            |
+| Code | Display | Omschrijving | Permissies |
+|:-----|:--------|:-------------|:-----------|
+| `behandelaar` | Behandelaar | Behandelend zorgverlener | Volledige CRUD rechten op patiënten in CareTeam |
+| `zorgondersteuner` | Zorgondersteuner | Ondersteunende rol (incl. administratief) | Taken klaarzetten, niet starten |
+| `case-manager` | Case Manager | Organisatie-brede coördinatie | Leestoegang organisatie-breed, taken starten |
 
-#### Specifieke familierelaties
+#### ValueSet
 
-Voor meer specifieke familierelaties kunnen de volgende codes worden gebruikt:
-
-| SNOMED CT Code | SNOMED CT Term           | Nederlandse term         |
-|:---------------|:-------------------------|:-------------------------|
-| `133932002`    | Caregiver (person)       | Familielid (algemeen)    |
-| `125677006`    | Relative (person)        | Ouder                    |
-| `125676002`    | Person (person)          | Kind                     |
-| `125678001`    | Family member (person)   | Echtgenoot/echtgenote    |
-| `125679009`    | Sibling (person)         | Broer/zus                |
-| `125680007`    | Friend (person)          | Vriend(in)               |
-
-#### Detailbeschrijving RelatedPerson codes
-
-##### 224610006 - Carer (person)
-
-Deze code wordt gebruikt voor mantelzorgers - personen die structureel informele zorg verlenen aan een patiënt. In het autorisatiemodel heeft de mantelzorger:
-- Leestoegang tot taken van de patiënt
-- Kan eigen taken uitvoeren
-- Beperkte uitvoeringsrechten namens de patiënt
-
-##### 419358007 - Legal guardian (person)
-
-Deze code wordt gebruikt voor wettelijk vertegenwoordigers - personen die juridisch gemachtigd zijn om namens de patiënt te handelen. In het autorisatiemodel heeft de wettelijk vertegenwoordiger:
-- Volledige toegang tot taken van de patiënt
-- Kan taken van de patiënt starten
-- Mag namens de patiënt handelen
-
-##### 133932002 - Caregiver (person)
-
-Deze code wordt gebruikt voor naasten - algemene verwanten of familieleden die betrokken zijn bij de zorg. In het autorisatiemodel heeft de naaste:
-- Leestoegang tot CareTeam informatie
-- Kan eigen taken uitvoeren
-- Ondersteunende en communicerende rol
-
-##### 125680007 - Friend (person)
-
-Deze code wordt gebruikt voor buddies en vrienden - personen met een niet-familiale relatie. In het autorisatiemodel heeft de buddy:
-- Vergelijkbare rechten als de naaste
-- Ondersteunende rol vanuit ervaringsdeskundigheid
-
----
-
-#### Mapping naar UZI/BIG rollen
-
-De mapping van UZI (Unieke Zorgverlener Identificatie) en BIG (Beroepen in de Individuele Gezondheidszorg) rollen naar de bovenstaande SNOMED CT codes dient nog nader te worden uitgewerkt. Hierbij zijn de volgende overwegingen van belang:
-
-1. **UZI rol-codes**: Het UZI-register kent eigen rol-codes die mogelijk niet 1-op-1 mappen naar SNOMED CT
-2. **BIG beroepen**: De BIG-registratie kent specifieke beroepscategorieën die vertaald moeten worden
-3. **Fallback strategie**: Wanneer een UZI/BIG code niet kan worden gemapped, valt de Practitioner terug op de "Overige rollen" categorie met minimale rechten
-
-#### Implementatieoverwegingen
-
-##### PractitionerRole resource
-
-De rol-code wordt vastgelegd in het `PractitionerRole.code` element:
-
-```json
-{
-  "resourceType": "PractitionerRole",
-  "code": [
-    {
-      "coding": [
-        {
-          "system": "http://snomed.info/sct",
-          "code": "405623001",
-          "display": "Assigned practitioner (occupation)"
-        }
-      ]
-    }
-  ]
-}
+```
+ValueSet: http://vzvz.nl/fhir/ValueSet/koppeltaal-practitioner-role
 ```
 
-##### CareTeam.participant.role
+Deze ValueSet bevat:
+- Alle codes uit de [ZorgverlenerRolCodelijst](https://simplifier.net/nictiz-r4-zib2020/2.16.840.1.113883.2.4.3.11.60.40.2.17.1.5--20200901000000) (backwards compatibility)
+- De Koppeltaal-specifieke autorisatierollen
 
-Voor het vastleggen van de rol binnen een CareTeam wordt het `CareTeam.participant.role` element gebruikt:
+#### Voorbeeld: Practitioner als Behandelaar
 
 ```json
 {
@@ -177,56 +65,135 @@ Voor het vastleggen van de rol binnen een CareTeam wordt het `CareTeam.participa
         {
           "coding": [
             {
-              "system": "http://snomed.info/sct",
-              "code": "405623001",
-              "display": "Assigned practitioner (occupation)"
+              "system": "http://vzvz.nl/fhir/CodeSystem/koppeltaal-careteam-role",
+              "code": "behandelaar",
+              "display": "Behandelaar"
             }
           ]
         }
       ],
       "member": {
-        "reference": "Practitioner/example"
+        "reference": "Practitioner/123"
       }
     }
   ]
 }
 ```
 
-##### RelatedPerson.relationship
+---
 
-Voor het vastleggen van de relatie van een RelatedPerson wordt het `RelatedPerson.relationship` element gebruikt:
+### RelatedPerson Relaties
+
+De onderstaande relaties zijn beschikbaar voor RelatedPersons binnen een CareTeam. De permissies per relatie zijn beschreven in [RelatedPerson autorisaties](autorisaties-relatedperson.html).
+
+| Code | Display | Omschrijving | Permissies |
+|:-----|:--------|:-------------|:-----------|
+| `naaste` | Naaste | Algemene naaste/verwant | Meekijken, ondersteunen, alleen eigen taken |
+| `mantelzorger` | Mantelzorger | Structurele informele zorgverlener | Meekijken, beperkt uitvoeren, leestoegang patiënttaken |
+| `wettelijk-vertegenwoordiger` | Wettelijk vertegenwoordiger | Juridisch gemachtigd persoon | Volledige toegang, namens patiënt handelen |
+| `buddy` | Buddy | Ervaringsdeskundige begeleider | Meekijken, ondersteunen, alleen eigen taken |
+
+#### ValueSet
+
+```
+ValueSet: http://vzvz.nl/fhir/ValueSet/koppeltaal-relatedperson-role
+```
+
+#### Voorbeeld: RelatedPerson als Mantelzorger
 
 ```json
 {
-  "resourceType": "RelatedPerson",
-  "patient": {
-    "reference": "Patient/example"
-  },
-  "relationship": [
+  "resourceType": "CareTeam",
+  "participant": [
     {
-      "coding": [
+      "role": [
         {
-          "system": "http://snomed.info/sct",
-          "code": "224610006",
-          "display": "Carer (person)"
+          "coding": [
+            {
+              "system": "http://vzvz.nl/fhir/CodeSystem/koppeltaal-careteam-role",
+              "code": "mantelzorger",
+              "display": "Mantelzorger"
+            }
+          ]
         }
-      ]
+      ],
+      "member": {
+        "reference": "RelatedPerson/456"
+      }
     }
   ]
 }
 ```
 
-#### Referenties
+---
 
-- [SNOMED CT Browser](https://browser.ihtsdotools.org/)
-- [FHIR R4 PractitionerRole ValueSet](https://www.hl7.org/fhir/R4/valueset-practitioner-role.html)
-- [FHIR R4 RelatedPerson Relationship ValueSet](https://www.hl7.org/fhir/R4/valueset-relatedperson-relationshiptype.html)
-- [Nictiz SNOMED CT](https://nictiz.nl/standaarden/overzicht-van-standaarden/snomed-ct/)
+### Autorisatielogica
+
+De autorisatielogica werkt als volgt:
+
+```
+┌─────────────────────────────────────────────────────────────────────────┐
+│  1. Haal CareTeam(s) op waar gebruiker lid van is                       │
+│     CareTeam?participant=Practitioner/{id}                              │
+│     CareTeam?participant=RelatedPerson/{id}                             │
+├─────────────────────────────────────────────────────────────────────────┤
+│  2. Bepaal rol binnen elk CareTeam                                      │
+│     CareTeam.participant[x].role.coding.code                            │
+├─────────────────────────────────────────────────────────────────────────┤
+│  3. Leid permissies af van rol via permissiematrix                      │
+│     behandelaar → CRUD op CareTeam resources                            │
+│     zorgondersteuner → CRUD taken, geen launch                          │
+│     etc.                                                                │
+├─────────────────────────────────────────────────────────────────────────┤
+│  4. Pas permissies toe bij resource access                              │
+│     Search narrowing, CRUD restricties                                  │
+└─────────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+### Fallback Gedrag
+
+#### Practitioner zonder Koppeltaal rol
+
+Wanneer een Practitioner wel lid is van een CareTeam maar geen Koppeltaal-specifieke rol heeft (alleen ZorgverlenerRolCodelijst code), gelden de regels van **"Practitioner zonder rol in CareTeam"**:
+- Alleen eigen taken en toegewezen resources
+- Minimale rechten
+
+#### RelatedPerson zonder rol
+
+Wanneer een RelatedPerson niet is opgenomen in een CareTeam of geen rol heeft, gelden de regels van **"Geen rol in CareTeam"**:
+- Alleen eigen taken
+- Geen toegang tot patiënttaken
+
+---
+
+### Implementatieoverwegingen
+
+#### Binding Strength
+
+De ValueSet bindings zijn `extensible`:
+- Koppeltaal codes MOETEN worden gebruikt voor autorisatie
+- Aanvullende codes (zoals ZorgverlenerRolCodelijst) MOGEN worden toegevoegd
+- Onbekende codes vallen terug op minimale rechten
+
+#### Meerdere Rollen
+
+Een participant kan meerdere `role` codings hebben. De autorisatielogica evalueert de **meest specifieke Koppeltaal code** die aanwezig is.
+
+#### Validatie
+
+De FHIR Validator accepteert:
+- Koppeltaal codes uit het eigen CodeSystem
+- Codes uit de ZorgverlenerRolCodelijst (via include in ValueSet)
+
+---
+
+### Referenties
+
+- [KoppeltaalCareTeamRole CodeSystem](CodeSystem-koppeltaal-careteam-role.html)
+- [KoppeltaalPractitionerRoleValueSet](ValueSet-koppeltaal-practitioner-role.html)
+- [KoppeltaalRelatedPersonRoleValueSet](ValueSet-koppeltaal-relatedperson-role.html)
 - [Practitioner autorisaties](autorisaties-practitioner.html)
 - [RelatedPerson autorisaties](autorisaties-relatedperson.html)
-
-#### Open vragen
-
-1. **Nederlandse extensie**: Zijn er specifieke SNOMED CT codes in de Nederlandse extensie die beter passen bij de gedefinieerde rollen?
-2. **UZI/BIG mapping**: Hoe wordt de vertaling van UZI/BIG codes naar SNOMED CT geïmplementeerd?
-3. **Granulariteit**: Is de huidige set codes voldoende specifiek, of zijn meer gedetailleerde codes nodig voor bepaalde use cases?
+- [CareTeam profiel](StructureDefinition-KT2CareTeam.html)


### PR DESCRIPTION
Replace SNOMED CT mapping approach with a dedicated Koppeltaal CodeSystem for CareTeam participant authorization roles. Custom codes prevent accidental permission assignment when resources enter Koppeltaal and provide no less interoperability than SNOMED for domain-specific authorization.

- Add KoppeltaalCareTeamRole CodeSystem with practitioner roles (behandelaar, zorgondersteuner, case-manager) and relatedperson roles (naaste, mantelzorger, wettelijk-vertegenwoordiger, buddy)
- Add separate ValueSets for Practitioner and RelatedPerson roles
- Remove unused combined ValueSet and alias
- Update KT2_CareTeam profile with new role slicing and bindings
- Update all examples to use custom roles instead of SNOMED/HL7v3
- Update documentation: notes, rol-code-mapping, relatedperson
- Add CareTeam test variants to generate_test_resources.py