### PR TITLE
feat: documenten delen — KT2DocumentReference profiel en expansion-code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 CHANGELOG
 
+## 0.16.3 (2026-06-09)
+
+### Toegevoegd
+- **KT2DocumentReference profiel**: nieuw profiel voor het delen van documenten vanuit een interventie (module) naar de dossierhouder (EPD). Verplicht `subject` (KT2_Patient), `type`, `date` en `content.attachment.url`; `context.related` bevat een verplichte slice `task` (verwijzing naar KT2_Task). Het profiel blijft open voor extensions. Eerste voorstel; nadere uitwerking volgt na afstemming met leveranciers.
+- **KoppeltaalExpansion codesysteem**: code `029-DocumentenDelen` ("Documenten Delen") toegevoegd voor aankondiging van documentoplevering via `ActivityDefinition.useContext`.
+- **Voorbeelden**: `documentreference-documenten-delen` (DocumentReference met externe referentie) en `activitydefinition-documenten-delen` (ActivityDefinition met de useContext-uitbreiding Documenten Delen).
+
 ## 0.16.2 (2026-04-02)
 
 ### Hersteld

--- a/input/fsh/codesystems/KoppeltaalExpansion.fsh
+++ b/input/fsh/codesystems/KoppeltaalExpansion.fsh
@@ -13,5 +13,6 @@ Description: "Optional expansions for Koppeltaal activities"
 * ^date = "2025-10-21T12:00:00+02:00"
 * insert ContactAndPublisher
 * ^caseSensitive = true
-* ^count = 1
+* ^count = 2
 * #026-RolvdNaaste "Rol van de naaste" "Met de \"Rol van de naaste\" uitbreiding kunnen naasten van de patiënt/cliënt deelnemen aan het zorgtraject van de patiënt/cliënt."
+* #029-DocumentenDelen "Documenten Delen" "Met de \"Documenten Delen\" uitbreiding kunnen applicaties op basis van Taken voor de patiënt een document door middel van een DocumentReference delen met andere applicaties in het domein."

--- a/input/fsh/examples/activitydefinition-documenten-delen.fsh
+++ b/input/fsh/examples/activitydefinition-documenten-delen.fsh
@@ -1,0 +1,22 @@
+Instance: activitydefinition-documenten-delen
+InstanceOf: ActivityDefinition
+Usage: #example
+Description: "Voorbeeld van een ActivityDefinition die via de useContext aankondigt dat de interventie een document oplevert (uitbreiding Documenten Delen)."
+* meta.profile = "http://koppeltaal.nl/fhir/StructureDefinition/KT2ActivityDefinition"
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>ActivityDefinition met de uitbreiding Documenten Delen</div>"
+* extension[0].url = "http://koppeltaal.nl/fhir/StructureDefinition/KT2PublisherId"
+* extension[=].valueId = "ID1234-003"
+* url = "https://module.example.org/catalogue/A1B2C3D4-0001-0002-0003-000400050006"
+* identifier.use = #official
+* identifier.system = "http://module.example.org/content/id"
+* identifier.value = "A1B2C3D4-0001-0002-0003-000400050006"
+* version = "2026-06-09T10:00:00"
+* name = "InterventieMetDocument"
+* title = "Interventie met documentoplevering"
+* status = #active
+* description = "Interventie die bij afronding een document (DocumentReference) oplevert."
+* useContext.code = http://vzvz.nl/fhir/CodeSystem/koppeltaal-usage-context-type#koppeltaal-expansion
+* useContext.valueCodeableConcept = http://vzvz.nl/fhir/CodeSystem/koppeltaal-expansion#029-DocumentenDelen "Documenten Delen"
+* topic = $koppeltaal-definition-topic#self-assessment

--- a/input/fsh/examples/documentreference-documenten-delen.fsh
+++ b/input/fsh/examples/documentreference-documenten-delen.fsh
@@ -1,0 +1,18 @@
+Instance: documentreference-documenten-delen
+InstanceOf: KT2_DocumentReference
+Description: "Voorbeeld van een DocumentReference die vanuit een interventie een voortgangsverslag deelt. De inhoud staat als externe referentie bij de bronapplicatie."
+Usage: #example
+* text
+  * status = #generated
+  * div = "<div xmlns='http://www.w3.org/1999/xhtml' xml:lang='nl-NL' lang='nl-NL'>Voorbeeld van een gedeeld document (voortgangsverslag)</div>"
+* insert NLlang
+* status = #current
+* type = http://loinc.org#11506-3 "Progress note"
+* subject = Reference(Patient/patient-volledigenaam)
+  * type = "Patient"
+* date = "2026-06-09T10:00:00+02:00"
+* content.attachment.contentType = #application/pdf
+* content.attachment.url = "https://module.example.org/fhir/Binary/2f1c8e9a-7b3d-4c1e-9a2f-6d5b4c3a2e10"
+* content.attachment.title = "Voortgangsverslag interventie"
+* context.related[task] = Reference(Task/task-minimaal)
+  * type = "Task"

--- a/input/fsh/profiles/KT2_DocumentReference.fsh
+++ b/input/fsh/profiles/KT2_DocumentReference.fsh
@@ -1,0 +1,35 @@
+Profile: KT2_DocumentReference
+Parent: DocumentReference
+Id: KT2DocumentReference
+Title: "KT2 DocumentReference"
+Description: "Het DocumentReference resource representeert een document dat vanuit een interventie (module) wordt gedeeld met de dossierhouder (EPD) binnen het Koppeltaal-ecosysteem. De Koppeltaal FHIR store bevat alleen de metadata; de inhoud blijft als externe referentie (`content.attachment.url`) bij de bronapplicatie. Dit profiel is een eerste voorstel; cardinaliteit, target-profielen en bindingen worden na afstemming met leveranciers verder uitgewerkt. Zie de pagina Documenten delen."
+* ^version = "0.1.0"
+* ^status = #draft
+* ^date = "2026-06-09"
+* insert ContactAndPublisher
+* insert Origin
+// Het document moet routeerbaar zijn naar het juiste dossier.
+* subject 1..1
+* subject only Reference(KT2_Patient)
+  * ^short = "De patiënt op wie het document betrekking heeft"
+// Ontvangers moeten het type document kunnen herkennen zonder de Binary te openen.
+// De binding/ValueSet (LOINC of een Koppeltaal-specifieke ValueSet) is nog een open punt.
+* type 1..1
+  * ^short = "Soort document (rapportage, vragenlijst-uitkomst, voortgangsverslag, etc.)"
+  * ^comment = "De binding/ValueSet voor `type` is nog uit te werken; zie de pagina Documenten delen (Open punten)."
+// Ankerpunt voor onder andere de bewaartermijn in de Koppeltaal-store.
+* date 1..1
+  * ^short = "Tijdstip waarop de DocumentReference is aangemaakt door de module"
+// Het document is altijd traceerbaar naar de Task waaruit het is voortgekomen.
+* context.related 1..*
+  * ^slicing.discriminator.type = #profile
+  * ^slicing.discriminator.path = "resolve()"
+  * ^slicing.rules = #open
+  * ^slicing.description = "Gerelateerde resources; minimaal een verwijzing naar de Task die de interventie representeert."
+* context.related contains task 1..1
+* context.related[task] only Reference(KT2_Task)
+  * ^short = "De Task waaruit het document is voortgekomen"
+  * ^definition = "Verwijzing naar de Task die de interventie representeert. Hiermee blijft het document traceerbaar naar de specifieke behandelopdracht."
+// De inhoud wordt uitgewisseld via externe referentie; de data blijft aan de bron.
+* content.attachment.url 1..
+  * ^short = "Externe referentie naar de Binary bij de bronapplicatie"

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -2,6 +2,13 @@
 
 Deze pagina bevat een overzicht van de wijzigingen per versie van de Koppeltaal 2.0 Implementation Guide.
 
+### 0.16.3 (2026-06-09)
+
+#### Toegevoegd
+- **KT2DocumentReference profiel**: nieuw profiel voor het delen van documenten vanuit een interventie (module) naar de dossierhouder (EPD). Verplicht `subject` (KT2_Patient), `type`, `date` en `content.attachment.url`; `context.related` bevat een verplichte slice `task` (verwijzing naar KT2_Task). Het profiel blijft open voor extensions. Eerste voorstel; nadere uitwerking volgt na afstemming met leveranciers.
+- **KoppeltaalExpansion codesysteem**: code `029-DocumentenDelen` ("Documenten Delen") toegevoegd voor aankondiging van documentoplevering via `ActivityDefinition.useContext`.
+- **Voorbeelden**: `documentreference-documenten-delen` (DocumentReference met externe referentie) en `activitydefinition-documenten-delen` (ActivityDefinition met de useContext-uitbreiding Documenten Delen).
+
 ### 0.16.2 (2026-04-02)
 
 #### Hersteld

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koppeltaalv2.00",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Draft of used FHIR resource profiles in Koppeltaal 2.0.",
   "title": "This package contains the Koppeltaal 2.0 profiles",
   "author": "VZVZ",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ fhirVersion: 4.0.1
 FSHOnly: false
 applyExtensionMetadataToRoot: false
 status: draft
-version: 0.16.2
+version: 0.16.3
 copyrightYear: 2024+
 releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html


### PR DESCRIPTION
## Samenvatting

Implementeert het FSH-voorstel uit `input/pagecontent/documenten-delen.md`: een eerste, expliciet als *voorstel* bedoelde uitwerking van "documenten delen" (module → EPD) in de FHIR-profielen.

## Wijzigingen (`input/fsh`)

- **`codesystems/KoppeltaalExpansion.fsh`** — nieuwe code `029-DocumentenDelen` ("Documenten Delen") voor aankondiging via `ActivityDefinition.useContext` (count 1→2).
- **`profiles/KT2_DocumentReference.fsh`** (nieuw, `Parent: DocumentReference`):
  - `subject 1..1` → `KT2_Patient`
  - `type 1..1` (nog geen harde binding — open punt)
  - `date 1..1`
  - `context.related 1..*` met verplichte slice **`task` 1..1** → `KT2_Task` (open slicing)
  - `content.attachment.url 1..` verplicht (externe referentie; inline `data` ongemoeid)
  - `insert Origin`; bewust **geen** `extension 0..0` zodat het profiel later "open" kan voor MedMij-extensions (memo KoppelMij §3.2)
- **`examples/documentreference-documenten-delen.fsh`** (nieuw)
- **`examples/activitydefinition-documenten-delen.fsh`** (nieuw)

## Versie

Micro-bump `0.16.2 → 0.16.3` (`sushi-config.yaml`, `package.json`) + Nederlandse changelog-entries (`CHANGELOG.md`, `input/pagecontent/changes.md`).

## Validatie

SUSHI in de Docker-builder: **0 errors** (12 profielen, 62 instances). De 3 warnings zijn bestaand en niet gerelateerd.

## Aandachtspunten

- Het profiel is een **eerste voorstel**. Binding voor `type`, scope-syntax en de definitieve uitbreidingscode blijven open punten (zie pagina Documenten delen).
- Profiel is bewust niet gesloten voor extensions, met het oog op de toekomstige "open" richting (KoppelMij/MedMij-context).

🤖 Generated with [Claude Code](https://claude.com/claude-code)