### PR TITLE
fix(auditevent): accept Patient ref in entity.what

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 CHANGELOG
 
+## 0.16.3 (2026-06-25)
+
+### Hersteld
+- **KT2AuditEvent**: `entity.what` expliciet vastgelegd als `Reference(Resource|*)` zodat de IG Publisher het doelprofiel niet versie-pint naar `Resource|4.0.1`. Die versie-pin brak de "elke resource"-afhandeling van de FHIR-validator, waardoor AuditEvents met een `Patient`-referentie in `entity.what` werden geweigerd (`Reference_REF_WrongTarget`).
+
 ## 0.16.2 (2026-04-02)
 
 ### Hersteld

--- a/input/fsh/profiles/KT2_AuditEvent.fsh
+++ b/input/fsh/profiles/KT2_AuditEvent.fsh
@@ -47,3 +47,9 @@ Description: "The AuditEvent resource is used to consolidate and track logging i
     * insert notUsedKT2
   * query ^comment = "Warning: name and query are mutually exclusive. Use query to register the full query, including parameters."
   * detail ..0
+// Keep the inherited Reference(Any) target UNVERSIONED. The IG Publisher (2.2.x) otherwise
+// version-pins it to .../Resource|4.0.1 during snapshot generation, which defeats the
+// org.hl7.fhir.core validator's "any resource" short-circuit (exact unversioned match) and
+// makes AuditEvent.entity.what -> Patient fail validation (Reference_REF_WrongTarget).
+// The trailing |* marker instructs the publisher not to pin this canonical.
+* entity.what only Reference(http://hl7.org/fhir/StructureDefinition/Resource|*)

--- a/input/ignoreWarnings.txt
+++ b/input/ignoreWarnings.txt
@@ -94,3 +94,9 @@ The HTML fragment 'ip-statements.xhtml' is not included anywhere in the produced
 An HTML fragment from the set [cross-version-analysis.xhtml, cross-version-analysis-inline.xhtml] is not included anywhere in the produced implementation guide
 An HTML fragment from the set [dependency-table.xhtml, dependency-table-short.xhtml, dependency-table-nontech.xhtml] is not included anywhere in the produced implementation guide
 The HTML fragment 'globals-table.xhtml' is not included anywhere in the produced implementation guide
+
+# |* no-pin marker on KT2AuditEvent.entity.what makes publisher 2.2.4 stamp a
+# version-resolution-method extension it cannot resolve itself; harmless (the
+# targetProfile value stays the bare Resource canonical that the validator needs).
+The extension http://hl7.org/fhir/StructureDefinition/version-resolution-method could not be found%
+No definition could be found for URL value 'http://hl7.org/fhir/StructureDefinition/version-resolution-method'

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -2,6 +2,11 @@
 
 Deze pagina bevat een overzicht van de wijzigingen per versie van de Koppeltaal 2.0 Implementation Guide.
 
+### 0.16.3 (2026-06-25)
+
+#### Hersteld
+- **KT2AuditEvent**: `entity.what` expliciet vastgelegd als `Reference(Resource|*)` zodat de IG Publisher het doelprofiel niet versie-pint naar `Resource|4.0.1`. Die versie-pin brak de "elke resource"-afhandeling van de FHIR-validator, waardoor AuditEvents met een `Patient`-referentie in `entity.what` werden geweigerd (`Reference_REF_WrongTarget`).
+
 ### 0.16.2 (2026-04-02)
 
 #### Hersteld

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koppeltaalv2.00",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "description": "Draft of used FHIR resource profiles in Koppeltaal 2.0.",
   "title": "This package contains the Koppeltaal 2.0 profiles",
   "author": "VZVZ",

--- a/sushi-config.yaml
+++ b/sushi-config.yaml
@@ -7,7 +7,7 @@ fhirVersion: 4.0.1
 FSHOnly: false
 applyExtensionMetadataToRoot: false
 status: draft
-version: 0.16.2
+version: 0.16.3
 copyrightYear: 2024+
 releaseLabel: ci-build
 # license: CC0-1.0 # https://www.hl7.org/fhir/valueset-spdx-license.html


### PR DESCRIPTION
## Problem
Since ~mid-March 2026 the auth-service can no longer create AuditEvents whose `entity.what` references a `Patient`. The FHIR validator rejects them on `AuditEvent.entity.what`:
- `Reference_REF_CantResolveProfile`: cannot resolve `http://hl7.org/fhir/StructureDefinition/Resource|4.0.1`
- `Reference_REF_WrongTarget`: type `Patient` is not a valid target (only `Resource|4.0.1`)

This is **not** a bug in the auth-service; it comes from the published KT2 package.

## Root cause
Base R4 `AuditEvent.entity.what` is `Reference(Any)`, encoded as targetProfile `.../StructureDefinition/Resource` (the abstract base). The KT2AuditEvent profile inherits this unchanged. **IG Publisher 2.2.x version-pins that inherited target to `.../Resource|4.0.1`** during snapshot generation. The `org.hl7.fhir.core` validator only treats `entity.what` as "any resource" when the target is the exact **unversioned** `.../Resource`; the pinned form defeats that short-circuit, so any typed `Patient` reference is rejected. This started with the `0.16.1` build — earlier packages had the bare, working target.

## Fix
Constrain `entity.what` to `Reference(Resource|*)`. The `|*` marker is the IG Publisher's documented "do not pin" instruction: it keeps the published target as the bare `.../Resource` the validator needs, while preserving `Reference(Any)` semantics. The cosmetic `version-resolution-method` extension messages the publisher emits for `|*` are suppressed in `ignoreWarnings.txt`.

## Verification (local IG build, publisher 2.2.4)
- `KT2AuditEvent.snapshot.entity.what.targetProfile` = `http://hl7.org/fhir/StructureDefinition/Resource` (unversioned)
- `auditevent-create-patient` / `auditevent-delete-patient` examples validate with **0 errors**
- build exits 0

## Notes
- Bumped to `0.16.3` (per merge convention, bump to `0.17.0` on merge to `main`).
- The underlying double-defect (publisher pinning an abstract "Any" target; the validator's non-version-aware short-circuit) is arguably an upstream bug worth reporting.
- Interim unblock without this release: omit the optional `"type":"Patient"` field from `entity.what` in the POSTed AuditEvent.
