### PR TITLE
fix(searchparameters): add Device target to resource-origin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 CHANGELOG
 
+## 0.16.3 (2026-07-02)
+
+### Hersteld
+- **SearchParameter resource-origin**: `target = Device` toegevoegd. De reference-SearchParameter had geen target-element, waardoor servers die `SearchParameter.target` gebruiken voor het valideren van getypeerde zoekwaarden (bijv. `resource-origin=Device/<id>` bij search narrowing) deze zoekopdrachten afwezen. De resource-origin-extensie verwijst uitsluitend naar (KT2_)Device.
+- **SearchParameter publisherId**: onterecht `target = ActivityDefinition` verwijderd; `target` is alleen van toepassing op reference-SearchParameters en dit is een token-parameter.
+
 ## 0.16.2 (2026-04-02)
 
 ### Hersteld

--- a/input/fsh/searchparameters/publisherId-extension.fsh
+++ b/input/fsh/searchparameters/publisherId-extension.fsh
@@ -18,4 +18,3 @@ Usage: #definition
 * expression = "ActivityDefinition.extension('http://koppeltaal.nl/fhir/StructureDefinition/KT2PublisherId')"
 * xpath = "f:ActivityDefinition/f:extension[@url='http://koppeltaal.nl/fhir/StructureDefinition/KT2PublisherId']"
 * xpathUsage = #normal
-* target = #ActivityDefinition

--- a/input/fsh/searchparameters/resource-origin-extension.fsh
+++ b/input/fsh/searchparameters/resource-origin-extension.fsh
@@ -26,5 +26,6 @@ Usage: #definition
 * base[+] = #OperationOutcome
 * base[+] = #Bundle
 * type = #reference
+* target = #Device
 * expression = "ActivityDefinition.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | CareTeam.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Device.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Organization.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Patient.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Practitioner.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | RelatedPerson.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Task.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | AuditEvent.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Endpoint.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin') | Subscription.extension('http://koppeltaal.nl/fhir/StructureDefinition/resource-origin')"
 * xpathUsage = #normal

--- a/input/pagecontent/changes.md
+++ b/input/pagecontent/changes.md
@@ -2,6 +2,12 @@
 
 Deze pagina bevat een overzicht van de wijzigingen per versie van de Koppeltaal 2.0 Implementation Guide.
 
+### 0.16.3 (2026-07-02)
+
+#### Hersteld
+- **SearchParameter resource-origin**: `target = Device` toegevoegd. De reference-SearchParameter had geen target-element, waardoor servers die `SearchParameter.target` gebruiken voor het valideren van getypeerde zoekwaarden (bijv. `resource-origin=Device/<id>` bij search narrowing) deze zoekopdrachten afwezen. De resource-origin-extensie verwijst uitsluitend naar (KT2_)Device.
+- **SearchParameter publisherId**: onterecht `target = ActivityDefinition` verwijderd; `target` is alleen van toepassing op reference-SearchParameters en dit is een token-parameter.
+
 ### 0.16.2 (2026-04-02)
 
 #### Hersteld


### PR DESCRIPTION
## Problem

An application instance with an OWN permission on Organization received the following error on a new domain when search narrowing injected `resource-origin=Device/<id>` into its search:

> The resource type 'Device' is not valid for search parameter 'resource-origin', it must be one of ().

The `resource-origin` SearchParameter is `type = reference` but declares no `target` element. Servers that use `SearchParameter.target` to validate typed reference search values therefore treat the allowed-type list as empty and reject the search.

This is not a regression: the SearchParameter has never declared a `target` in **any** published release — verified in all package versions from 0.7.1 (2022) through 0.16.2, in both the JSON and XML renditions. Example: [0.12.0](https://simplifier.net/resolve?scope=koppeltaalv2.00@0.12.0&canonical=http://koppeltaal.nl/fhir/SearchParameter/resource-origin-extension) · [0.16.2](https://simplifier.net/resolve?scope=koppeltaalv2.00@0.16.2&canonical=http://koppeltaal.nl/fhir/SearchParameter/resource-origin-extension).

## Why `target = Device` is correct

- The `resource-origin` extension is constrained to `value[x] only Reference(KT2_Device)`, so Device is the only type the expression can yield.
- `SearchParameter.target` is `0..*` in R4 (no invariant requires it), but FHIR core practice is to declare it: 471 of 472 core reference search parameters do.
- R5 makes the intent explicit ([SearchParameter.target definition](https://hl7.org/fhir/R5/searchparameter-definitions.html#SearchParameter.target)): "the list of targets SHOULD cover all targets that might appear that are permitted by the specified FHIRPath."
- The extension constraint governs write-time instance validation; `target` is the machine-readable search metadata needed for typed values, chaining, `_include` and `_has`. Both belong there by design.

## Changes

- `resource-origin` SearchParameter: add `target = Device`.
- `publisherId` SearchParameter: remove the spurious `target = ActivityDefinition` — `target` only applies to reference search parameters and this is a token parameter. This one has carried the spurious target since its first appearance in [0.9.3](https://simplifier.net/resolve?scope=koppeltaalv2.00@0.9.3&canonical=http://koppeltaal.nl/fhir/SearchParameter/publisherId-extension), in every release through [0.16.2](https://simplifier.net/resolve?scope=koppeltaalv2.00@0.16.2&canonical=http://koppeltaal.nl/fhir/SearchParameter/publisherId-extension) — likely a copy-paste at creation, never changed since. (The other search parameters were reviewed: `task-instantiates` already declares its target correctly; the remaining token parameters correctly have none.)
- Package version stays at 0.16.2 (no per-PR bump); CHANGELOG.md and changes.md entries are collected under the upcoming 0.16.3 release, alongside the entity.what fix branch.

Not included (left for a follow-up if desired): aligning `base` with `expression` on `resource-origin` — `Bundle` and `OperationOutcome` are listed in `base` but have no extraction path in the expression, and Bundle cannot carry the extension at all (no root `extension` element in R4).

## Verification

`sushi` build passes with 0 errors (3 pre-existing slicing warnings, unrelated). Generated output confirmed: `SearchParameter-resource-origin-extension.json` now has `"target": ["Device"]`; `SearchParameter-publisherId-extension.json` no longer has a `target`.
