### PR TITLE
fix(ci): work around tx.fhir.org slowdown in package builds

### DIFF
--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -233,8 +233,9 @@ jobs:
           PUBLISH_VERSION="${{ needs.build.outputs.version }}"
           # For non-main branches, append the branch name and short commit hash to make version unique
           if [ "${{ github.ref_name }}" != "main" ]; then
-            # Sanitize branch name for npm version (replace / with -, remove special chars)
-            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            # Sanitize branch name for npm version: semver prerelease identifiers only
+            # allow alphanumerics and hyphens, so underscores etc. must become hyphens
+            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g')
             PUBLISH_VERSION="${PUBLISH_VERSION}-${BRANCH_NAME}-${GITHUB_SHA::7}"
           fi
 
@@ -293,8 +294,9 @@ jobs:
           PUBLISH_VERSION="${{ needs.build.outputs.version }}-minimal"
           # For non-main branches, append the branch name and short commit hash to make version unique
           if [ "${{ github.ref_name }}" != "main" ]; then
-            # Sanitize branch name for npm version (replace / with -, remove special chars)
-            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9._-]/-/g')
+            # Sanitize branch name for npm version: semver prerelease identifiers only
+            # allow alphanumerics and hyphens, so underscores etc. must become hyphens
+            BRANCH_NAME=$(echo "${{ github.ref_name }}" | sed 's/[^a-zA-Z0-9-]/-/g')
             PUBLISH_VERSION="${PUBLISH_VERSION}-${BRANCH_NAME}-${GITHUB_SHA::7}"
           fi
 

--- a/.github/workflows/build_deploy.yml
+++ b/.github/workflows/build_deploy.yml
@@ -63,13 +63,29 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+      # tx.fhir.org has become very slow (server-side cache sessions get dropped, every
+      # validation call takes minutes). Persist the publisher's local terminology cache
+      # across runs so repeated validations never hit the network. The unique key forces
+      # a fresh save each run; restore-keys picks up the most recent previous cache.
+      - name: Restore terminology cache (txCache)
+        uses: actions/cache@v4
+        with:
+          path: input-cache/txcache
+          key: txcache-${{ github.run_id }}
+          restore-keys: |
+            txcache-
+
       - name: Build FHIR Packages
         env:
           FHIR_EMAIL: ${{ secrets.FHIR_EMAIL }}
           FHIR_PASSWORD: ${{ secrets.FHIR_PASSWORD }}
+          # main: full terminology validation, but retry previously failed tx calls so
+          # cached errors don't poison the published ValueSet expansions.
+          # branches: skip the terminology server entirely for fast feedback.
+          TX_OPTS: ${{ github.ref == 'refs/heads/main' && '-resetTxErrors' || '-tx n/a' }}
         run: |
           # Run build-minimal which produces both full (./output) and minimal (./output-minimal) packages
-          docker run -v ${PWD}:/src -e FHIR_EMAIL=${FHIR_EMAIL} -e FHIR_PASSWORD=${FHIR_PASSWORD} localhost:5000/koppeltaal-builder:latest build-minimal
+          docker run -v ${PWD}:/src -e FHIR_EMAIL=${FHIR_EMAIL} -e FHIR_PASSWORD=${FHIR_PASSWORD} -e TX_OPTS="${TX_OPTS}" localhost:5000/koppeltaal-builder:latest build-minimal
 
       - name: Upload full build artifacts
         uses: actions/upload-artifact@v4

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM mcr.microsoft.com/dotnet/sdk:8.0
 
 # Build argument for IG Publisher version
-ARG PUBLISHER_VERSION=2.2.4
+ARG PUBLISHER_VERSION=2.2.10
 ARG SUSHI_VERSION=3.16.5
 
 RUN dotnet tool install -g firely.terminal && apt-get update && apt install -y make jq default-jdk python3 python3-pip python3-yaml graphviz plantuml jekyll nodejs npm

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,11 @@ endif
 # Export PATH with dotnet tools
 export PATH := $(PATH):$(DOTNET_TOOLS)
 
+# Extra flags for the IG publisher terminology handling. Examples:
+#   TX_OPTS="-tx n/a"          skip the terminology server entirely (fast, no code validation)
+#   TX_OPTS="-resetTxErrors"   retry previously failed terminology calls, keep cached successes
+TX_OPTS ?=
+
 # Default target
 .PHONY: all
 all: build
@@ -45,7 +50,7 @@ install-dependencies:
 .PHONY: build-ig
 build-ig:
 	@echo "Building Full Implementation Guide with version $(VERSION)..."
-	java -jar /usr/local/publisher.jar -ig ig.ini
+	java -jar /usr/local/publisher.jar -ig ig.ini $(TX_OPTS)
 	@echo "Fixing extension version references..."
 	@python3 scripts/fix_extension_versions.py output
 	@if [ ! -f ./output/package.tgz ]; then \


### PR DESCRIPTION
## Problem

Since late June, CI builds went from ~5 minutes to 2+ hours (one run took 25 hours). The cause is **tx.fhir.org**, not the package registry: the terminology server drops the IG Publisher's server-side cache sessions (`The cache '…' is not known to this server`), so every `codeInValueSet` validation call takes ~3 minutes. It also intermittently broke ValueSet expansions in the published package (`koppeltaal-practitioner-role`, `koppeltaal-relatedperson-role`).

The publisher's local terminology cache (`input-cache/txcache`) was never persisted in CI ("0 files in cache" every run), so each build paid the full price.

## Changes

- **Persist txCache across CI runs** with `actions/cache` — repeated terminology validations no longer hit the network
- **`TX_OPTS` make variable** passed into the docker build:
  - `main`: `-resetTxErrors` — full validation, but previously failed tx calls are retried so cached errors can't poison published expansions
  - branches: `-tx n/a` — skip the terminology server for fast feedback
- **IG Publisher 2.2.4 → 2.2.10** (released right when the server behavior changed)
- **Fix branch-name sanitization** for npm prerelease versions: semver forbids underscores, which broke the GitHub Packages publish jobs for this branch

## Results

- Branch build on this PR: [4 minutes, fully green](https://github.com/vzvznl/Koppeltaal-2.0-FHIR/actions/runs/29324906512) (was 125+ minutes)
- Note: the **first** main build after merge is still slow (warms the txCache with full validation); subsequent main builds should be fast

## Trade-off

Branch builds no longer validate codes against the terminology server: PR QA reports won't flag invalid codes, and branch pre-release packages lack ValueSet expansions. Main builds keep full validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)